### PR TITLE
Update @codemirror/* packages and move to peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,7 @@
       "name": "@emmetio/codemirror6-plugin",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/basic-setup": "^0.19.0",
-        "@codemirror/lang-css": "^0.19.3",
-        "@codemirror/lang-html": "^0.19.4",
-        "@codemirror/language": "^0.19.7",
-        "@codemirror/state": "^0.19.6",
-        "@codemirror/view": "^0.19.25",
+        "@codemirror/language": "^0.19.5",
         "@emmetio/action-utils": "^1.2.2",
         "@emmetio/css-matcher": "^1.0.2",
         "@emmetio/html-matcher": "^1.3.0",
@@ -21,6 +16,11 @@
         "emmet": "^2.3.4"
       },
       "devDependencies": {
+        "@codemirror/basic-setup": "^0.19.0",
+        "@codemirror/lang-css": "^0.19.3",
+        "@codemirror/lang-html": "^0.19.3",
+        "@codemirror/state": "^0.19.5",
+        "@codemirror/view": "^0.19.19",
         "typescript": "^4.3.2",
         "vite": "^2.6.4"
       }
@@ -29,6 +29,7 @@
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
       "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -42,6 +43,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz",
       "integrity": "sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/closebrackets": "^0.19.0",
@@ -64,6 +66,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
       "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -76,6 +79,7 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
       "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -89,6 +93,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
       "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -99,6 +104,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.1.tgz",
       "integrity": "sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -111,6 +117,7 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
       "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -121,6 +128,7 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
       "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -134,6 +142,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
       "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -143,6 +152,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
       "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -152,9 +162,10 @@
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
-      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
+      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -170,6 +181,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
       "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
+      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -181,9 +193,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
-      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
+      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -196,6 +208,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
       "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/gutter": "^0.19.4",
         "@codemirror/panel": "^0.19.0",
@@ -210,6 +223,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
       "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -221,6 +235,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
       "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -238,6 +253,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz",
       "integrity": "sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.4",
@@ -248,6 +264,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
       "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
+      "dev": true,
       "dependencies": {
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -258,9 +275,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
+      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
       "dependencies": {
         "@codemirror/text": "^0.19.0"
       }
@@ -274,15 +291,16 @@
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.7.tgz",
       "integrity": "sha512-yJ1OAVX8zJfPiwn2jcaXCJCGwq837+osu+Rfjx/1x9ZW3lGDP2o7nvsk+E/gItzdLCnQUQDJpFX4pHcMSADZ0g==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "0.19.25",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
-      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
+      "version": "0.19.19",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
+      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
       "dependencies": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -355,6 +373,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
       "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -363,6 +382,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
       "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
+      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -371,6 +391,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.1.tgz",
       "integrity": "sha512-EnfO9MF2yDMpN2DEovPbKKdi4tj1phuolBxcEDC35cx+OUfToweMOEBZHr/nhHI79+6HkLMoCK2coch+PT+oBA==",
+      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -386,7 +407,8 @@
     "node_modules/crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "dev": true
     },
     "node_modules/emmet": {
       "version": "2.3.4",
@@ -836,6 +858,7 @@
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
       "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
+      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -849,6 +872,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz",
       "integrity": "sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==",
+      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/closebrackets": "^0.19.0",
@@ -871,6 +895,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
       "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
+      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -883,6 +908,7 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
       "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
+      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -896,6 +922,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
       "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -906,6 +933,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.1.tgz",
       "integrity": "sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==",
+      "dev": true,
       "requires": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -918,6 +946,7 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
       "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
+      "dev": true,
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -928,6 +957,7 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
       "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
+      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -941,6 +971,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
       "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -950,6 +981,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
       "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -959,9 +991,10 @@
       }
     },
     "@codemirror/lang-html": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
-      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
+      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
+      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -977,6 +1010,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
       "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
+      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -988,9 +1022,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
-      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
+      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -1003,6 +1037,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
       "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "dev": true,
       "requires": {
         "@codemirror/gutter": "^0.19.4",
         "@codemirror/panel": "^0.19.0",
@@ -1017,6 +1052,7 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
       "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
+      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -1028,6 +1064,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
       "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -1045,6 +1082,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz",
       "integrity": "sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.4",
@@ -1055,6 +1093,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
       "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
+      "dev": true,
       "requires": {
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -1065,9 +1104,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
+      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -1081,15 +1120,16 @@
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.7.tgz",
       "integrity": "sha512-yJ1OAVX8zJfPiwn2jcaXCJCGwq837+osu+Rfjx/1x9ZW3lGDP2o7nvsk+E/gItzdLCnQUQDJpFX4pHcMSADZ0g==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.25",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
-      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
+      "version": "0.19.19",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
+      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -1162,6 +1202,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
       "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1170,6 +1211,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
       "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
+      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1178,6 +1220,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.1.tgz",
       "integrity": "sha512-EnfO9MF2yDMpN2DEovPbKKdi4tj1phuolBxcEDC35cx+OUfToweMOEBZHr/nhHI79+6HkLMoCK2coch+PT+oBA==",
+      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1193,7 +1236,8 @@
     "crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "dev": true
     },
     "emmet": {
       "version": "2.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@emmetio/codemirror6-plugin",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/language": "^0.19.5",
         "@emmetio/action-utils": "^1.2.2",
         "@emmetio/css-matcher": "^1.0.2",
         "@emmetio/html-matcher": "^1.3.0",
@@ -18,11 +17,19 @@
       "devDependencies": {
         "@codemirror/basic-setup": "^0.19.0",
         "@codemirror/lang-css": "^0.19.3",
-        "@codemirror/lang-html": "^0.19.3",
-        "@codemirror/state": "^0.19.5",
-        "@codemirror/view": "^0.19.19",
+        "@codemirror/lang-html": "^0.19.4",
+        "@codemirror/language": "^0.19.7",
+        "@codemirror/state": "^0.19.6",
+        "@codemirror/view": "^0.19.25",
         "typescript": "^4.3.2",
         "vite": "^2.6.4"
+      },
+      "peerDependencies": {
+        "@codemirror/lang-css": ">=0.19.0",
+        "@codemirror/lang-html": ">=0.19.0",
+        "@codemirror/language": ">=0.19.0",
+        "@codemirror/state": ">=0.19.0",
+        "@codemirror/view": ">=0.19.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -162,9 +169,9 @@
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
-      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
       "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
@@ -193,9 +200,10 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
+      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -245,6 +253,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
       "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0"
       }
@@ -275,9 +284,10 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
-      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
+      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/text": "^0.19.0"
       }
@@ -285,7 +295,8 @@
     "node_modules/@codemirror/text": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==",
+      "dev": true
     },
     "node_modules/@codemirror/tooltip": {
       "version": "0.19.7",
@@ -298,9 +309,10 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "0.19.19",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
-      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
+      "version": "0.19.25",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
+      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
+      "dev": true,
       "dependencies": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -367,7 +379,8 @@
     "node_modules/@lezer/common": {
       "version": "0.15.8",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
-      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig=="
+      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==",
+      "dev": true
     },
     "node_modules/@lezer/css": {
       "version": "0.15.2",
@@ -400,6 +413,7 @@
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
       "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "dev": true,
       "dependencies": {
         "@lezer/common": "^0.15.0"
       }
@@ -448,19 +462,6 @@
         "esbuild-windows-arm64": "0.13.14"
       }
     },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
-      "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/esbuild-darwin-64": {
       "version": "0.13.14",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
@@ -472,201 +473,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
-      "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
-      "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
-      "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
-      "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
-      "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
-      "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
-      "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
-      "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
-      "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
-      "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ]
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
-      "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
-      "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ]
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
-      "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
-      "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
-      "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/fsevents": {
@@ -795,7 +601,8 @@
     "node_modules/style-mod": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.5.2",
@@ -850,7 +657,8 @@
     "node_modules/w3c-keyname": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -991,9 +799,9 @@
       }
     },
     "@codemirror/lang-html": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
-      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
       "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
@@ -1022,9 +830,10 @@
       }
     },
     "@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
+      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -1074,6 +883,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
       "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
+      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
@@ -1104,9 +914,10 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
-      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
+      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
+      "dev": true,
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -1114,7 +925,8 @@
     "@codemirror/text": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==",
+      "dev": true
     },
     "@codemirror/tooltip": {
       "version": "0.19.7",
@@ -1127,9 +939,10 @@
       }
     },
     "@codemirror/view": {
-      "version": "0.19.19",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
-      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
+      "version": "0.19.25",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
+      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
+      "dev": true,
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -1196,7 +1009,8 @@
     "@lezer/common": {
       "version": "0.15.8",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
-      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig=="
+      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==",
+      "dev": true
     },
     "@lezer/css": {
       "version": "0.15.2",
@@ -1229,6 +1043,7 @@
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
       "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "dev": true,
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -1273,122 +1088,10 @@
         "esbuild-windows-arm64": "0.13.14"
       }
     },
-    "esbuild-android-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
-      "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
-      "dev": true,
-      "optional": true
-    },
     "esbuild-darwin-64": {
       "version": "0.13.14",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
       "integrity": "sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
-      "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
-      "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
-      "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
-      "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
-      "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
-      "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
-      "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
-      "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
-      "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
-      "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
-      "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
-      "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
-      "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
-      "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
-      "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
       "dev": true,
       "optional": true
     },
@@ -1480,7 +1183,8 @@
     "style-mod": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "dev": true
     },
     "typescript": {
       "version": "4.5.2",
@@ -1504,7 +1208,8 @@
     "w3c-keyname": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,12 @@
       "name": "@emmetio/codemirror6-plugin",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/language": "^0.19.5",
+        "@codemirror/basic-setup": "^0.19.0",
+        "@codemirror/lang-css": "^0.19.3",
+        "@codemirror/lang-html": "^0.19.4",
+        "@codemirror/language": "^0.19.7",
+        "@codemirror/state": "^0.19.6",
+        "@codemirror/view": "^0.19.25",
         "@emmetio/action-utils": "^1.2.2",
         "@emmetio/css-matcher": "^1.0.2",
         "@emmetio/html-matcher": "^1.3.0",
@@ -16,11 +21,6 @@
         "emmet": "^2.3.4"
       },
       "devDependencies": {
-        "@codemirror/basic-setup": "^0.19.0",
-        "@codemirror/lang-css": "^0.19.3",
-        "@codemirror/lang-html": "^0.19.3",
-        "@codemirror/state": "^0.19.5",
-        "@codemirror/view": "^0.19.19",
         "typescript": "^4.3.2",
         "vite": "^2.6.4"
       }
@@ -29,7 +29,6 @@
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
       "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -43,7 +42,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz",
       "integrity": "sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/closebrackets": "^0.19.0",
@@ -66,7 +64,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
       "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -79,7 +76,6 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
       "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -93,7 +89,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
       "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -104,7 +99,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.1.tgz",
       "integrity": "sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -117,7 +111,6 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
       "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -128,7 +121,6 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
       "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -142,7 +134,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
       "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -152,7 +143,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
       "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -162,10 +152,9 @@
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
-      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
-      "dev": true,
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -181,7 +170,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
       "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
-      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -193,9 +181,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
+      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -208,7 +196,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
       "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
-      "dev": true,
       "dependencies": {
         "@codemirror/gutter": "^0.19.4",
         "@codemirror/panel": "^0.19.0",
@@ -223,7 +210,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
       "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
-      "dev": true,
       "dependencies": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -235,7 +221,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
       "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -253,7 +238,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz",
       "integrity": "sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.4",
@@ -264,7 +248,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
       "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
-      "dev": true,
       "dependencies": {
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -275,9 +258,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
-      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
+      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
       "dependencies": {
         "@codemirror/text": "^0.19.0"
       }
@@ -291,16 +274,15 @@
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.7.tgz",
       "integrity": "sha512-yJ1OAVX8zJfPiwn2jcaXCJCGwq837+osu+Rfjx/1x9ZW3lGDP2o7nvsk+E/gItzdLCnQUQDJpFX4pHcMSADZ0g==",
-      "dev": true,
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "0.19.19",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
-      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
+      "version": "0.19.25",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
+      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
       "dependencies": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -373,7 +355,6 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
       "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
-      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -382,7 +363,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
       "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
-      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -391,7 +371,6 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.1.tgz",
       "integrity": "sha512-EnfO9MF2yDMpN2DEovPbKKdi4tj1phuolBxcEDC35cx+OUfToweMOEBZHr/nhHI79+6HkLMoCK2coch+PT+oBA==",
-      "dev": true,
       "dependencies": {
         "@lezer/lr": "^0.15.0"
       }
@@ -407,8 +386,7 @@
     "node_modules/crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
-      "dev": true
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
     },
     "node_modules/emmet": {
       "version": "2.3.4",
@@ -858,7 +836,6 @@
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
       "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -872,7 +849,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz",
       "integrity": "sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==",
-      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/closebrackets": "^0.19.0",
@@ -895,7 +871,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
       "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -908,7 +883,6 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.5.tgz",
       "integrity": "sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -922,7 +896,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
       "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -933,7 +906,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.1.tgz",
       "integrity": "sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==",
-      "dev": true,
       "requires": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -946,7 +918,6 @@
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
       "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
-      "dev": true,
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -957,7 +928,6 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
       "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -971,7 +941,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
       "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -981,7 +950,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
       "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
-      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -991,10 +959,9 @@
       }
     },
     "@codemirror/lang-html": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.3.tgz",
-      "integrity": "sha512-QlZN8VhQ+vlOpDMbcfXcG3HiiNeklAfIYnKonPM902SM3nJc4rJ66X9O8mzy0TUDBmew9zaYDubvQcqw7rc5Bg==",
-      "dev": true,
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -1010,7 +977,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
       "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
-      "dev": true,
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.6",
@@ -1022,9 +988,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
+      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -1037,7 +1003,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
       "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
-      "dev": true,
       "requires": {
         "@codemirror/gutter": "^0.19.4",
         "@codemirror/panel": "^0.19.0",
@@ -1052,7 +1017,6 @@
       "version": "0.19.3",
       "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz",
       "integrity": "sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==",
-      "dev": true,
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -1064,7 +1028,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
       "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
@@ -1082,7 +1045,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz",
       "integrity": "sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.4",
@@ -1093,7 +1055,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.2.tgz",
       "integrity": "sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==",
-      "dev": true,
       "requires": {
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -1104,9 +1065,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.5.tgz",
-      "integrity": "sha512-a3bJnkFuh4Z36nuOzAYobWViQ9eq5ux2wOb/46jUl+0Sj2BGrdz+pY1L+y2NUZhwPyWGcIrBtranr5P0rEEq8A==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
+      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -1120,16 +1081,15 @@
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.7.tgz",
       "integrity": "sha512-yJ1OAVX8zJfPiwn2jcaXCJCGwq837+osu+Rfjx/1x9ZW3lGDP2o7nvsk+E/gItzdLCnQUQDJpFX4pHcMSADZ0g==",
-      "dev": true,
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.19",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.19.tgz",
-      "integrity": "sha512-SG4idEsBwe4tKG1+aM2cyfeHarWDWRXBqX9J0R6CvG24XfpObtDNnosZZ5ktdm+j0Z1wIMe9H4C31cuyTJRvWQ==",
+      "version": "0.19.25",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.25.tgz",
+      "integrity": "sha512-tJ4AnDeSyAIwUsm+lU4VRH9apMMYXcKNYM28bObTKQWV9qjTbra1UZXvQfq7/0yfp3Oituai5f90bFhakCKsyA==",
       "requires": {
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
@@ -1202,7 +1162,6 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
       "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
-      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1211,7 +1170,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
       "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
-      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1220,7 +1178,6 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.1.tgz",
       "integrity": "sha512-EnfO9MF2yDMpN2DEovPbKKdi4tj1phuolBxcEDC35cx+OUfToweMOEBZHr/nhHI79+6HkLMoCK2coch+PT+oBA==",
-      "dev": true,
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -1236,8 +1193,7 @@
     "crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
-      "dev": true
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
     },
     "emmet": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "serve": "vite preview"
   },
   "devDependencies": {
+    "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/lang-css": "^0.19.3",
+    "@codemirror/lang-html": "^0.19.3",
+    "@codemirror/state": "^0.19.5",
+    "@codemirror/view": "^0.19.19",
     "typescript": "^4.3.2",
     "vite": "^2.6.4"
   },
   "dependencies": {
-    "@codemirror/basic-setup": "^0.19.0",
-    "@codemirror/lang-css": "^0.19.3",
-    "@codemirror/lang-html": "^0.19.4",
-    "@codemirror/language": "^0.19.7",
-    "@codemirror/state": "^0.19.6",
-    "@codemirror/view": "^0.19.25",
+    "@codemirror/language": "^0.19.5",
     "@emmetio/action-utils": "^1.2.2",
     "@emmetio/css-matcher": "^1.0.2",
     "@emmetio/html-matcher": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -6,17 +6,24 @@
     "build": "tsc && vite build",
     "serve": "vite preview"
   },
+  "peerDependencies": {
+    "@codemirror/lang-css": ">=0.19.0",
+    "@codemirror/lang-html": ">=0.19.0",
+    "@codemirror/language": ">=0.19.0",
+    "@codemirror/state": ">=0.19.0",
+    "@codemirror/view": ">=0.19.0"
+  },
   "devDependencies": {
     "@codemirror/basic-setup": "^0.19.0",
     "@codemirror/lang-css": "^0.19.3",
-    "@codemirror/lang-html": "^0.19.3",
-    "@codemirror/state": "^0.19.5",
-    "@codemirror/view": "^0.19.19",
+    "@codemirror/lang-html": "^0.19.4",
+    "@codemirror/language": "^0.19.7",
+    "@codemirror/state": "^0.19.6",
+    "@codemirror/view": "^0.19.25",
     "typescript": "^4.3.2",
     "vite": "^2.6.4"
   },
   "dependencies": {
-    "@codemirror/language": "^0.19.5",
     "@emmetio/action-utils": "^1.2.2",
     "@emmetio/css-matcher": "^1.0.2",
     "@emmetio/html-matcher": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@codemirror/basic-setup": "^0.19.0",
-    "@codemirror/lang-css": "^0.19.3",
-    "@codemirror/lang-html": "^0.19.3",
-    "@codemirror/state": "^0.19.5",
-    "@codemirror/view": "^0.19.19",
     "typescript": "^4.3.2",
     "vite": "^2.6.4"
   },
   "dependencies": {
-    "@codemirror/language": "^0.19.5",
+    "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/lang-css": "^0.19.3",
+    "@codemirror/lang-html": "^0.19.4",
+    "@codemirror/language": "^0.19.7",
+    "@codemirror/state": "^0.19.6",
+    "@codemirror/view": "^0.19.25",
     "@emmetio/action-utils": "^1.2.2",
     "@emmetio/css-matcher": "^1.0.2",
     "@emmetio/html-matcher": "^1.3.0",


### PR DESCRIPTION
Hey Sergey!

I noticed that some of the `@codemirror` packages were out of date and also wanted to suggest that the relevant ones (e.g. those not used solely by the Vite demo app) be moved to peer dependencies.

This is better than listing them under dependencies since the versions can get out of date with a user's app that's depending on this package which leads to subtle bugs, or in the case of multiple versions of `@codemirror/state`, altogether breakage of the editor.

See the issue described here for an example of where we ran into this: https://github.com/sachinraja/codemirror-lang-elixir/issues/2

We do this for all of the CM packages we publish too. e.g. https://github.com/replit/Codemirror-CSS-color-picker/blob/441daeab50da21d59c22af7f6128bca9c7d59e65/package.json#L24-L37

Thanks!