### PR TITLE
Fix Vite config to support commands other than build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,5 +17,7 @@ export default defineConfig(({ command }) => {
                 }
             }
         };
+    } else {
+        return {};
     }
 });


### PR DESCRIPTION
Looks like the Vite config is currently set up in such a way that only the build command is supported (only build returns an object) which means that e.g. `npm run dev` and `npm run serve` fail with an error.

This is fixed by returning an empty object for commands other than `build`.