### PR TITLE
Introduce Noise Filter for HTML suggestions

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -194,3 +194,12 @@ export function getSelectionsFromSnippet(snippet: string, base = 0): { ranges: R
         snippet: result + snippet.slice(offset)
     };
 }
+
+export const commonlyUsedTags = {
+    html: [
+        "body", "head", "html",
+        "address", "blockquote", "dd", "div", "section", "article", "aside", "header", "footer", "nav", "menu", "dl", "dt", "fieldset", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "iframe", "noframes", "object", "ol", "p", "ul", "applet", "center", "dir", "hr", "pre",
+        "a", "abbr", "acronym", "area", "b", "base", "basefont", "bdo", "big", "br", "button", "caption", "cite", "code", "col", "colgroup", "del", "dfn", "em", "font", "i", "img", "input", "ins", "isindex", "kbd", "label", "legend", "li", "link", "map", "meta", "noscript", "optgroup", "option", "param", "q", "s", "samp", "script", "select", "small", "span", "strike", "strong", "style", "sub", "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", "tt", "u", "var",
+        "canvas", "main", "figure", "plaintext", "figcaption", "hgroup", "details", "summary"
+    ]
+}


### PR DESCRIPTION
## Why
I referenced this pain point here: https://github.com/emmetio/codemirror6-plugin/issues/18 

There should be a way to tone down the "noise" that Emmet generates, particularly when expanding strings of text, such as `thisisalongstringoftext`, into invalid HTML tags (`<thisisalongstringoftext></thisisalongstringoftext>`).


For context, at Replit we're trying to merge the emmet expansion into our autocomplete dropdown, but can't have an overly-noisy autocomplete. 

There is prior art for this. I looked through VSCode's implementation of Emmet, and found the [VSCode Emmet Helper](https://github.com/microsoft/vscode-emmet-helper) repo. It has a [similar filter for noisy results](https://github.com/microsoft/vscode-emmet-helper/blob/8fd9b23266929f7e6e1e2b9aa327dc362edd3cc8/src/emmetHelper.ts#L527) that includes a check against [common HTML tags](
https://github.com/microsoft/vscode-emmet-helper/blob/main/src/data.ts), among other checks.

For now I started simply and handled my highest priority case - the noisy expanding HTML tags. Though this function could become a place to add additional filtering in the future, or introduce a configuration option to expose noise filtering to the plugin user.

## What changed

* Introduced a noise filter for HTML expand results that filters out expanded strings that don't match a list of common HTML tags.
* The list of tags was copied directly from https://github.com/microsoft/vscode-emmet-helper/blob/main/src/data.ts

## Test plan
See video below. Now, random strings like "hello" and "world" don't trigger an emmet expansion, while expected tags still work perfectly:

https://user-images.githubusercontent.com/16962017/220497675-a7ea947b-ed1e-4986-841a-5403f011a1aa.mov



