### PR TITLE
Switch EmmetKnownSyntax to enum

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,148 +1,151 @@
-import type { GlobalConfig } from 'emmet';
-import { EditorState, type Extension, Facet } from '@codemirror/state';
-import { resetCache } from './emmet';
-import type { EmmetKnownSyntax } from './types';
+import type { GlobalConfig } from "emmet";
+import { EditorState, type Extension, Facet } from "@codemirror/state";
+import { resetCache } from "./emmet";
+import { EmmetKnownSyntax } from "./types";
 
 export interface EmmetEditorOptions {
-    emmet: EmmetConfig;
+  emmet: EmmetConfig;
 }
 
 export type EnableForSyntax = boolean | string[];
 export type PreviewExtensions = () => Extension;
 
 export interface EmmetPreviewConfig {
-    /** Extensions factory for displaying HTML-like abbreviation preview  */
-    html?: PreviewExtensions;
-    /** Extensions factory for displaying CSS-like abbreviation preview  */
-    css?: PreviewExtensions;
+  /** Extensions factory for displaying HTML-like abbreviation preview  */
+  html?: PreviewExtensions;
+  /** Extensions factory for displaying CSS-like abbreviation preview  */
+  css?: PreviewExtensions;
 }
 
 export interface EmmetConfig {
-    /**
-     * A syntax of expanded abbreviations. In most cases, it must be the same syntax
-     * as in your editor. Currently, CodeMirror doesn’t provide API to get syntax
-     * name from host editor so you have to specify it manually.
-     */
-    syntax: EmmetKnownSyntax;
+  /**
+   * A syntax of expanded abbreviations. In most cases, it must be the same syntax
+   * as in your editor. Currently, CodeMirror doesn’t provide API to get syntax
+   * name from host editor so you have to specify it manually.
+   */
+  syntax: EmmetKnownSyntax;
 
-    /** Enables abbreviation marking in editor. Works in known syntaxes only */
-    mark: EnableForSyntax;
+  /** Enables abbreviation marking in editor. Works in known syntaxes only */
+  mark: EnableForSyntax;
 
-    /**
-     * Config for proview popup
-     */
-    preview: EmmetPreviewConfig;
+  /**
+   * Config for proview popup
+   */
+  preview: EmmetPreviewConfig;
 
-    /**
-     * Enables preview of marked abbreviation. Pass `true` to enable preview for
-     * all syntaxes or array of modes or Emmet syntax types (`markup` or `stylesheet`)
-     * where preview should be displayed
-     */
-    previewEnabled: EnableForSyntax;
+  /**
+   * Enables preview of marked abbreviation. Pass `true` to enable preview for
+   * all syntaxes or array of modes or Emmet syntax types (`markup` or `stylesheet`)
+   * where preview should be displayed
+   */
+  previewEnabled: EnableForSyntax;
 
-    /** Mark HTML tag pairs in editor */
-    markTagPairs: boolean;
+  /** Mark HTML tag pairs in editor */
+  markTagPairs: boolean;
 
-    /**
-     * Displays open tag preview when caret is inside its matching closing tag.
-     * Preview is displayed only if open tag has attributes.
-     * Works only if `markTagPairs` is enabled
-     */
-    previewOpenTag: boolean;
+  /**
+   * Displays open tag preview when caret is inside its matching closing tag.
+   * Preview is displayed only if open tag has attributes.
+   * Works only if `markTagPairs` is enabled
+   */
+  previewOpenTag: boolean;
 
-    /** Allow automatic tag pair rename, works only if `markTagPairs` is enabled */
-    autoRenameTags: boolean;
+  /** Allow automatic tag pair rename, works only if `markTagPairs` is enabled */
+  autoRenameTags: boolean;
 
-    /** Quotes to use in generated HTML attribute values */
-    attributeQuotes: 'single' | 'double';
+  /** Quotes to use in generated HTML attribute values */
+  attributeQuotes: "single" | "double";
 
-    /** Style for self-closing elements (like `<br>`) and boolean attributes */
-    markupStyle: 'html' | 'xhtml' | 'xml',
+  /** Style for self-closing elements (like `<br>`) and boolean attributes */
+  markupStyle: "html" | "xhtml" | "xml";
 
-    /**
-     * Enable automatic tag commenting. When enabled, elements generated from Emmet
-     * abbreviation with `id` and/or `class` attributes will receive a comment
-     * with these attribute values
-     */
-    comments: boolean;
+  /**
+   * Enable automatic tag commenting. When enabled, elements generated from Emmet
+   * abbreviation with `id` and/or `class` attributes will receive a comment
+   * with these attribute values
+   */
+  comments: boolean;
 
-    /**
-     * Commenting template. Default value is `\n<!-- /[#ID][.CLASS] -->`
-     * Outputs everything between `[` and `]` only if specified attribute name
-     * (written in UPPERCASE) exists in element. Attribute name is replaced with
-     * actual value. Use `\n` to add a newline.
-     */
-    commentsTemplate?: string;
+  /**
+   * Commenting template. Default value is `\n<!-- /[#ID][.CLASS] -->`
+   * Outputs everything between `[` and `]` only if specified attribute name
+   * (written in UPPERCASE) exists in element. Attribute name is replaced with
+   * actual value. Use `\n` to add a newline.
+   */
+  commentsTemplate?: string;
 
-    /**
-     * Enable BEM support. When enabled, Emmet will treat class names starting
-     * with `-` as _element_ and with `_` as _modifier_ in BEM notation.
-     * These class names will inherit `block` name from current or ancestor element.
-     * For example, the abbreviation `ul.nav.nav_secondary>li.nav__item` can be
-     * shortened to `ul.nav._secondary>li.-item` with this option enabled.
-     */
-    bem: boolean;
+  /**
+   * Enable BEM support. When enabled, Emmet will treat class names starting
+   * with `-` as _element_ and with `_` as _modifier_ in BEM notation.
+   * These class names will inherit `block` name from current or ancestor element.
+   * For example, the abbreviation `ul.nav.nav_secondary>li.nav__item` can be
+   * shortened to `ul.nav._secondary>li.-item` with this option enabled.
+   */
+  bem: boolean;
 
-    /**
-     * For stylesheet abbreviations, generate short HEX color values, if possible.
-     * For example, `c#0` will be expanded to `color: #000;` instead of `color: #000000`.
-     */
-    shortHex?: boolean;
+  /**
+   * For stylesheet abbreviations, generate short HEX color values, if possible.
+   * For example, `c#0` will be expanded to `color: #000;` instead of `color: #000000`.
+   */
+  shortHex?: boolean;
 
-    /** Advanced Emmet config */
-    config?: GlobalConfig;
+  /** Advanced Emmet config */
+  config?: GlobalConfig;
 
-    /**
-     * A `boost` option for CodeMirror completions
-     */
-    completionBoost?: number;
+  /**
+   * A `boost` option for CodeMirror completions
+   */
+  completionBoost?: number;
 
-    /**
-     * Function for attaching abbreviation preview
-     */
-    // attachPreview?: (editor: CodeMirror.Editor, preview: HTMLElement, pos: CodeMirror.Position) => void;
+  /**
+   * Function for attaching abbreviation preview
+   */
+  // attachPreview?: (editor: CodeMirror.Editor, preview: HTMLElement, pos: CodeMirror.Position) => void;
 }
 
 export const defaultConfig: EmmetConfig = {
-    syntax: 'html',
-    mark: true,
-    preview: { },
-    previewEnabled: true,
-    autoRenameTags: true,
-    markTagPairs: true,
-    previewOpenTag: false,
-    attributeQuotes: 'double',
-    markupStyle: 'html',
-    comments: false,
-    commentsTemplate: '<!-- /[#ID][.CLASS] -->',
-    bem: false,
-    completionBoost: 99
+  syntax: EmmetKnownSyntax.html,
+  mark: true,
+  preview: {},
+  previewEnabled: true,
+  autoRenameTags: true,
+  markTagPairs: true,
+  previewOpenTag: false,
+  attributeQuotes: "double",
+  markupStyle: "html",
+  comments: false,
+  commentsTemplate: "<!-- /[#ID][.CLASS] -->",
+  bem: false,
+  completionBoost: 99,
 };
 
 export const config = Facet.define<Partial<EmmetConfig>, EmmetConfig>({
-    combine(value) {
-        resetCache();
-        const baseConfig: EmmetConfig = { ...defaultConfig };
-        const { preview } = baseConfig;
-        for (const item of value) {
-            Object.assign(baseConfig, item);
-            if (item.preview) {
-                baseConfig.preview = {
-                    ...preview,
-                    ...item.preview
-                };
-            }
-        }
-
-        return baseConfig;
+  combine(value) {
+    resetCache();
+    const baseConfig: EmmetConfig = { ...defaultConfig };
+    const { preview } = baseConfig;
+    for (const item of value) {
+      Object.assign(baseConfig, item);
+      if (item.preview) {
+        baseConfig.preview = {
+          ...preview,
+          ...item.preview,
+        };
+      }
     }
+
+    return baseConfig;
+  },
 });
 
-export default function getEmmetConfig(state: EditorState, opt?: Partial<EmmetConfig>): EmmetConfig {
-    let conf = state.facet(config);
-    if (opt) {
-        conf = { ...conf, ...opt };
-    }
+export default function getEmmetConfig(
+  state: EditorState,
+  opt?: Partial<EmmetConfig>
+): EmmetConfig {
+  let conf = state.facet(config);
+  if (opt) {
+    conf = { ...conf, ...opt };
+  }
 
-    return conf;
+  return conf;
 }

--- a/src/lib/emmet.ts
+++ b/src/lib/emmet.ts
@@ -1,17 +1,34 @@
-import type { EditorState } from '@codemirror/state';
-import { syntaxTree } from '@codemirror/language';
-import type { SyntaxNode } from '@lezer/common';
-import expandAbbreviation, { extract as extractAbbreviation, resolveConfig } from 'emmet';
-import type { UserConfig, AbbreviationContext, ExtractedAbbreviation, Options, ExtractOptions, MarkupAbbreviation, StylesheetAbbreviation, SyntaxType } from 'emmet';
-import { syntaxInfo, getMarkupAbbreviationContext, getStylesheetAbbreviationContext } from './syntax';
-import { getTagAttributes, substr } from './utils';
-import getEmmetConfig from './config';
-import getOutputOptions, { field } from './output';
-import type { ContextTag } from './types';
+import type { EditorState } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import type { SyntaxNode } from "@lezer/common";
+import expandAbbreviation, {
+  extract as extractAbbreviation,
+  resolveConfig,
+} from "emmet";
+import type {
+  UserConfig,
+  AbbreviationContext,
+  ExtractedAbbreviation,
+  Options,
+  ExtractOptions,
+  MarkupAbbreviation,
+  StylesheetAbbreviation,
+  SyntaxType,
+} from "emmet";
+import {
+  syntaxInfo,
+  getMarkupAbbreviationContext,
+  getStylesheetAbbreviationContext,
+} from "./syntax";
+import { getTagAttributes, substr } from "./utils";
+import getEmmetConfig from "./config";
+import getOutputOptions, { field } from "./output";
+import { EmmetKnownSyntax, type ContextTag } from "./types";
 
-export interface ExtractedAbbreviationWithContext extends ExtractedAbbreviation {
-    context?: AbbreviationContext;
-    inline?: boolean;
+export interface ExtractedAbbreviationWithContext
+  extends ExtractedAbbreviation {
+  context?: AbbreviationContext;
+  inline?: boolean;
 }
 
 /**
@@ -20,32 +37,36 @@ export interface ExtractedAbbreviationWithContext extends ExtractedAbbreviation 
  */
 let cache = {};
 
-export const JSX_PREFIX = '<';
+export const JSX_PREFIX = "<";
 
 /**
  * Expands given abbreviation into code snippet
  */
-export function expand(state: EditorState, abbr: string | MarkupAbbreviation | StylesheetAbbreviation, config?: UserConfig) {
-    let opt: UserConfig = { cache };
-    const outputOpt: Partial<Options> = {
-        'output.field': field,
-    };
+export function expand(
+  state: EditorState,
+  abbr: string | MarkupAbbreviation | StylesheetAbbreviation,
+  config?: UserConfig
+) {
+  let opt: UserConfig = { cache };
+  const outputOpt: Partial<Options> = {
+    "output.field": field,
+  };
 
-    if (config) {
-        Object.assign(opt, config);
-        if (config.options) {
-            Object.assign(outputOpt, config.options);
-        }
+  if (config) {
+    Object.assign(opt, config);
+    if (config.options) {
+      Object.assign(outputOpt, config.options);
     }
+  }
 
-    opt.options = outputOpt;
+  opt.options = outputOpt;
 
-    const pluginConfig = getEmmetConfig(state);
-    if (pluginConfig.config) {
-        opt = resolveConfig(opt, pluginConfig.config);
-    }
+  const pluginConfig = getEmmetConfig(state);
+  if (pluginConfig.config) {
+    opt = resolveConfig(opt, pluginConfig.config);
+  }
 
-    return expandAbbreviation(abbr as string, opt);
+  return expandAbbreviation(abbr as string, opt);
 }
 
 /**
@@ -59,83 +80,91 @@ export function expand(state: EditorState, abbr: string | MarkupAbbreviation | S
  * @param pos Location at which abbreviation should be expanded
  * @param type Syntax of abbreviation to expand
  */
-export function extract(code: string, pos: number, type: SyntaxType = 'markup', options?: Partial<ExtractOptions>): ExtractedAbbreviation | undefined {
-    return extractAbbreviation(code, pos, {
-        lookAhead: type !== 'stylesheet',
-        type,
-        ...options
-    });
+export function extract(
+  code: string,
+  pos: number,
+  type: SyntaxType = "markup",
+  options?: Partial<ExtractOptions>
+): ExtractedAbbreviation | undefined {
+  return extractAbbreviation(code, pos, {
+    lookAhead: type !== "stylesheet",
+    type,
+    ...options,
+  });
 }
 
 /**
  * Returns matched HTML/XML tag for given point in view
  */
-export function getTagContext(state: EditorState, pos: number): ContextTag | undefined {
-    let element: SyntaxNode | null = syntaxTree(state).resolve(pos, 1);
-    while (element && element.name !== 'Element') {
-        element = element.parent;
+export function getTagContext(
+  state: EditorState,
+  pos: number
+): ContextTag | undefined {
+  let element: SyntaxNode | null = syntaxTree(state).resolve(pos, 1);
+  while (element && element.name !== "Element") {
+    element = element.parent;
+  }
+
+  if (element) {
+    const selfClose = element.getChild("SelfClosingTag");
+    if (selfClose) {
+      return {
+        name: getTagName(state, selfClose),
+        attributes: getTagAttributes(state, selfClose),
+        open: selfClose,
+      };
     }
 
-    if (element) {
-        const selfClose = element.getChild('SelfClosingTag');
-        if (selfClose) {
-            return {
-                name: getTagName(state, selfClose),
-                attributes: getTagAttributes(state, selfClose),
-                open: selfClose
-            }
-        }
+    const openTag = element.getChild("OpenTag");
+    if (openTag) {
+      const closeTag = element.getChild("CloseTag");
+      const ctx: ContextTag = {
+        name: getTagName(state, openTag),
+        attributes: getTagAttributes(state, openTag),
+        open: openTag,
+      };
 
-        const openTag = element.getChild('OpenTag');
-        if (openTag) {
-            const closeTag = element.getChild('CloseTag');
-            const ctx: ContextTag = {
-                name: getTagName(state, openTag),
-                attributes: getTagAttributes(state, openTag),
-                open: openTag,
-            };
+      if (closeTag) {
+        ctx.close = closeTag;
+      }
 
-            if (closeTag) {
-                ctx.close = closeTag;
-            }
-
-            return ctx;
-        }
+      return ctx;
     }
+  }
 
-    return;
+  return;
 }
 
 export function getTagName(state: EditorState, node: SyntaxNode): string {
-    const tagName = node.getChild('TagName');
-    return tagName ? substr(state, tagName) : '';
+  const tagName = node.getChild("TagName");
+  return tagName ? substr(state, tagName) : "";
 }
 
 /**
  * Returns Emmet options for given character location in editor
  */
 export function getOptions(state: EditorState, pos: number): UserConfig {
-    const info = syntaxInfo(state, pos);
-    const { context } = info;
+  const info = syntaxInfo(state, pos);
+  const { context } = info;
 
-    const config: UserConfig = {
-        type: info.type,
-        syntax: info.syntax || 'html',
-        options: getOutputOptions(state, info.inline)
-    };
+  const config: UserConfig = {
+    type: info.type,
+    syntax: info.syntax || EmmetKnownSyntax.html,
+    options: getOutputOptions(state, info.inline),
+  };
 
-    if (context) {
-        // Set context from syntax info
-        if (context.type === 'html' && context.ancestors.length) {
-            config.context = getMarkupAbbreviationContext(state, context);
-        } else if (context.type === 'css') {
-            config.context = getStylesheetAbbreviationContext(context);
-        }
+  if (context) {
+    // Set context from syntax info
+    if (context.type === "html" && context.ancestors.length) {
+      config.context = getMarkupAbbreviationContext(state, context);
+    } else if (context.type === "css") {
+      config.context = getStylesheetAbbreviationContext(context);
     }
+  }
 
-    return config;
+  return config;
 }
 
 export function resetCache() {
-    cache = {};
+  cache = {};
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,60 +1,64 @@
-import type { Options } from 'emmet';
-import type { EditorState, Line } from '@codemirror/state';
-import getEmmetConfig from './config';
-import { isHTML, docSyntax } from './syntax';
+import type { Options } from "emmet";
+import type { EditorState, Line } from "@codemirror/state";
+import getEmmetConfig from "./config";
+import { isHTML, docSyntax } from "./syntax";
+import { EmmetKnownSyntax } from "./types";
 
-export default function getOutputOptions(state: EditorState, inline?: boolean): Partial<Options> {
-    const syntax = docSyntax(state) || 'html';
-    const config = getEmmetConfig(state);
+export default function getOutputOptions(
+  state: EditorState,
+  inline?: boolean
+): Partial<Options> {
+  const syntax = docSyntax(state) || EmmetKnownSyntax.html;
+  const config = getEmmetConfig(state);
 
-    const opt: Partial<Options> = {
-        // 'output.baseIndent': lineIndent(state.doc.lineAt(pos)),
-        // 'output.indent': getIndentation(state),
-        'output.field': field,
-        'output.indent': '\t',
-        'output.format': !inline,
-        'output.attributeQuotes': config.attributeQuotes,
-        'stylesheet.shortHex': config.shortHex
-    };
+  const opt: Partial<Options> = {
+    // 'output.baseIndent': lineIndent(state.doc.lineAt(pos)),
+    // 'output.indent': getIndentation(state),
+    "output.field": field,
+    "output.indent": "\t",
+    "output.format": !inline,
+    "output.attributeQuotes": config.attributeQuotes,
+    "stylesheet.shortHex": config.shortHex,
+  };
 
-    if (syntax === 'html') {
-        opt['output.selfClosingStyle'] = config.markupStyle;
-        opt['output.compactBoolean'] = config.markupStyle === 'html';
+  if (syntax === EmmetKnownSyntax.html) {
+    opt["output.selfClosingStyle"] = config.markupStyle;
+    opt["output.compactBoolean"] = config.markupStyle === EmmetKnownSyntax.html;
+  }
+
+  if (isHTML(syntax)) {
+    if (config.comments) {
+      opt["comment.enabled"] = true;
+      if (config.commentsTemplate) {
+        opt["comment.after"] = config.commentsTemplate;
+      }
     }
 
-    if (isHTML(syntax)) {
-        if (config.comments) {
-            opt['comment.enabled'] = true;
-            if (config.commentsTemplate) {
-                opt['comment.after'] = config.commentsTemplate;
-            }
-        }
+    opt["bem.enabled"] = config.bem;
+  }
 
-        opt['bem.enabled'] = config.bem;
-    }
-
-    return opt;
+  return opt;
 }
 
 /**
  * Produces tabstop for CodeMirror editor
  */
 export function field(index: number, placeholder?: string) {
-    return placeholder ? `\${${index}:${placeholder}}` : `\${${index}}`;
+  return placeholder ? `\${${index}:${placeholder}}` : `\${${index}}`;
 }
 
 /**
  * Returns indentation of given line
  */
 export function lineIndent(line: Line): string {
-    const indent = line.text.match(/^\s+/);
-    return indent ? indent[0] : '';
+  const indent = line.text.match(/^\s+/);
+  return indent ? indent[0] : "";
 }
 
 /**
  * Returns token used for single indentation in given editor
  */
 export function getIndentation(state: EditorState): string {
-    const { tabSize } = state;
-    return tabSize ? ' '.repeat(tabSize) : '\t';
+  const { tabSize } = state;
+  return tabSize ? " ".repeat(tabSize) : "\t";
 }

--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -1,52 +1,81 @@
-import type { SyntaxType, AbbreviationContext } from 'emmet';
-import type { EditorState } from '@codemirror/state';
-import { syntaxTree } from '@codemirror/language';
-import type { SyntaxNode } from '@lezer/common';
-import { getContext } from './context';
-import type { HTMLContext, CSSContext, EmmetKnownSyntax } from './types';
-import { last, getTagAttributes } from './utils';
-import getEmmetConfig from './config';
+import type { SyntaxType, AbbreviationContext } from "emmet";
+import type { EditorState } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import type { SyntaxNode } from "@lezer/common";
+import { getContext } from "./context";
+import { EmmetKnownSyntax } from "./types";
+import type { HTMLContext, CSSContext } from "./types";
+import { last, getTagAttributes } from "./utils";
+import getEmmetConfig from "./config";
 
-const htmlSyntaxes: EmmetKnownSyntax[] = ['html', 'vue'];
-const jsxSyntaxes: EmmetKnownSyntax[] = ['jsx', 'tsx'];
-const xmlSyntaxes: EmmetKnownSyntax[] = ['xml', 'xsl', ...jsxSyntaxes];
-const cssSyntaxes: EmmetKnownSyntax[] = ['css', 'scss', 'less'];
-const markupSyntaxes: EmmetKnownSyntax[] = ['haml', 'jade', 'pug', 'slim', ...htmlSyntaxes, ...xmlSyntaxes, ...jsxSyntaxes];
-const stylesheetSyntaxes: EmmetKnownSyntax[] = ['sass', 'sss', 'stylus', 'postcss', ...cssSyntaxes];
+const htmlSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.html,
+  EmmetKnownSyntax.vue,
+];
+const jsxSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.jsx,
+  EmmetKnownSyntax.tsx,
+];
+const xmlSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.xml,
+  EmmetKnownSyntax.xsl,
+  ...jsxSyntaxes,
+];
+const cssSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.css,
+  EmmetKnownSyntax.scss,
+  EmmetKnownSyntax.less,
+];
+const markupSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.haml,
+  EmmetKnownSyntax.jade,
+  EmmetKnownSyntax.pug,
+  EmmetKnownSyntax.slim,
+  ...htmlSyntaxes,
+  ...xmlSyntaxes,
+  ...jsxSyntaxes,
+];
+const stylesheetSyntaxes: EmmetKnownSyntax[] = [
+  EmmetKnownSyntax.sass,
+  EmmetKnownSyntax.sss,
+  EmmetKnownSyntax.stylus,
+  EmmetKnownSyntax.postcss,
+  ...cssSyntaxes,
+];
 
 export interface SyntaxInfo {
-    type: SyntaxType;
-    syntax?: string;
-    inline?: boolean;
-    context?: HTMLContext | CSSContext;
+  type: SyntaxType;
+  syntax?: string;
+  inline?: boolean;
+  context?: HTMLContext | CSSContext;
 }
 
 export interface StylesheetRegion {
-    range: [number, number];
-    syntax: string;
-    inline?: boolean;
+  range: [number, number];
+  syntax: string;
+  inline?: boolean;
 }
 
 export interface SyntaxCache {
-    stylesheetRegions?: StylesheetRegion[];
+  stylesheetRegions?: StylesheetRegion[];
 }
 
 const enum TokenType {
-    Selector = "selector",
-    PropertyName = "propertyName",
-    PropertyValue = "propertyValue",
-    BlockEnd = "blockEnd"
+  Selector = "selector",
+  PropertyName = "propertyName",
+  PropertyValue = "propertyValue",
+  BlockEnd = "blockEnd",
 }
 
 const enum CSSAbbreviationScope {
-    /** Include all possible snippets in match */
-    Global = "@@global",
-    /** Include raw snippets only (e.g. no properties) in abbreviation match */
-    Section = "@@section",
-    /** Include properties only in abbreviation match */
-    Property = "@@property",
-    /** Resolve abbreviation in context of CSS property value */
-    Value = "@@value"
+  /** Include all possible snippets in match */
+  Global = "@@global",
+  /** Include raw snippets only (e.g. no properties) in abbreviation match */
+  Section = "@@section",
+  /** Include properties only in abbreviation match */
+  Property = "@@property",
+  /** Resolve abbreviation in context of CSS property value */
+  Value = "@@value",
 }
 
 /**
@@ -58,61 +87,68 @@ const enum CSSAbbreviationScope {
  * returns `null`, but if `fallback` argument is provided, it returns data for
  * given fallback syntax
  */
-export function syntaxInfo(state: EditorState, ctx?: number | HTMLContext | CSSContext): SyntaxInfo {
-    let syntax = docSyntax(state);
-    let inline: boolean | undefined;
-    let context = typeof ctx === 'number' ? getContext(state, ctx) : ctx;
+export function syntaxInfo(
+  state: EditorState,
+  ctx?: number | HTMLContext | CSSContext
+): SyntaxInfo {
+  let syntax = docSyntax(state);
+  let inline: boolean | undefined;
+  let context = typeof ctx === "number" ? getContext(state, ctx) : ctx;
 
-    if (context?.type === 'html' && context.css) {
-        inline = true;
-        syntax = 'css';
-        context = context.css;
-    } else if (context?.type === 'css') {
-        syntax = 'css';
-    }
+  if (context?.type === "html" && context.css) {
+    inline = true;
+    syntax = "css";
+    context = context.css;
+  } else if (context?.type === "css") {
+    syntax = "css";
+  }
 
-    return {
-        type: getSyntaxType(syntax),
-        syntax,
-        inline,
-        context
-    };
+  return {
+    type: getSyntaxType(syntax),
+    syntax,
+    inline,
+    context,
+  };
 }
 
 /**
  * Returns main editor syntax
  */
 export function docSyntax(state: EditorState): EmmetKnownSyntax {
-    return getEmmetConfig(state).syntax;
+  return getEmmetConfig(state).syntax;
 }
 
 /**
  * Returns Emmet abbreviation type for given syntax
  */
 export function getSyntaxType(syntax?: EmmetKnownSyntax): SyntaxType {
-    return syntax && stylesheetSyntaxes.includes(syntax) ? 'stylesheet' : 'markup';
+  return syntax && stylesheetSyntaxes.includes(syntax)
+    ? "stylesheet"
+    : "markup";
 }
 
 /**
  * Check if given syntax is XML dialect
  */
 export function isXML(syntax: string): syntax is EmmetKnownSyntax {
-    return xmlSyntaxes.includes(syntax as EmmetKnownSyntax);
+  return xmlSyntaxes.includes(syntax as EmmetKnownSyntax);
 }
 
 /**
  * Check if given syntax is HTML dialect (including XML)
  */
 export function isHTML(syntax: string): syntax is EmmetKnownSyntax {
-    return htmlSyntaxes.includes(syntax as EmmetKnownSyntax) || isXML(syntax);
+  return htmlSyntaxes.includes(syntax as EmmetKnownSyntax) || isXML(syntax);
 }
 
 /**
  * Check if given syntax name is supported by Emmet
  */
 export function isSupported(syntax: string): syntax is EmmetKnownSyntax {
-    return markupSyntaxes.includes(syntax as EmmetKnownSyntax)
-        || stylesheetSyntaxes.includes(syntax as EmmetKnownSyntax);
+  return (
+    markupSyntaxes.includes(syntax as EmmetKnownSyntax) ||
+    stylesheetSyntaxes.includes(syntax as EmmetKnownSyntax)
+  );
 }
 
 /**
@@ -120,57 +156,69 @@ export function isSupported(syntax: string): syntax is EmmetKnownSyntax {
  * syntax: for example, SASS is a stylesheet but not CSS dialect (but SCSS is)
  */
 export function isCSS(syntax: string): syntax is EmmetKnownSyntax {
-    return cssSyntaxes.includes(syntax as EmmetKnownSyntax);
+  return cssSyntaxes.includes(syntax as EmmetKnownSyntax);
 }
 
 /**
  * Check if given syntax is JSX dialect
  */
 export function isJSX(syntax: string): syntax is EmmetKnownSyntax {
-    return jsxSyntaxes.includes(syntax as EmmetKnownSyntax);
+  return jsxSyntaxes.includes(syntax as EmmetKnownSyntax);
 }
 
 /**
  * Returns context for Emmet abbreviation from given HTML context
  */
-export function getMarkupAbbreviationContext(state: EditorState, ctx: HTMLContext): AbbreviationContext | undefined {
-    const parent = last(ctx.ancestors);
-    if (parent) {
-        let node: SyntaxNode | null = syntaxTree(state).resolve(parent.range.from, 1);
-        while (node && node.name !== 'OpenTag') {
-            node = node.parent;
-        }
-
-        return {
-            name: parent.name,
-            attributes: node ? getTagAttributes(state, node) : {}
-        };
+export function getMarkupAbbreviationContext(
+  state: EditorState,
+  ctx: HTMLContext
+): AbbreviationContext | undefined {
+  const parent = last(ctx.ancestors);
+  if (parent) {
+    let node: SyntaxNode | null = syntaxTree(state).resolve(
+      parent.range.from,
+      1
+    );
+    while (node && node.name !== "OpenTag") {
+      node = node.parent;
     }
 
-    return;
+    return {
+      name: parent.name,
+      attributes: node ? getTagAttributes(state, node) : {},
+    };
+  }
+
+  return;
 }
 
 /**
  * Returns context for Emmet abbreviation from given CSS context
  */
-export function getStylesheetAbbreviationContext(ctx: CSSContext): AbbreviationContext {
-    if (ctx.inline) {
-        return { name: CSSAbbreviationScope.Property }
-    }
+export function getStylesheetAbbreviationContext(
+  ctx: CSSContext
+): AbbreviationContext {
+  if (ctx.inline) {
+    return { name: CSSAbbreviationScope.Property };
+  }
 
-    const parent = last(ctx.ancestors);
-    let scope: string = CSSAbbreviationScope.Global;
-    if (ctx.current) {
-        if (ctx.current.type === TokenType.PropertyValue && parent) {
-            scope = parent.name;
-        } else if ((ctx.current.type === TokenType.Selector || ctx.current.type === TokenType.PropertyName) && !parent) {
-            scope = CSSAbbreviationScope.Section;
-        }
-    } else if (!parent) {
-        scope = CSSAbbreviationScope.Section;
+  const parent = last(ctx.ancestors);
+  let scope: string = CSSAbbreviationScope.Global;
+  if (ctx.current) {
+    if (ctx.current.type === TokenType.PropertyValue && parent) {
+      scope = parent.name;
+    } else if (
+      (ctx.current.type === TokenType.Selector ||
+        ctx.current.type === TokenType.PropertyName) &&
+      !parent
+    ) {
+      scope = CSSAbbreviationScope.Section;
     }
+  } else if (!parent) {
+    scope = CSSAbbreviationScope.Section;
+  }
 
-    return {
-        name: scope
-    };
+  return {
+    name: scope,
+  };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,90 +1,106 @@
-import type { AbbreviationContext, UserConfig } from 'emmet';
-import type { EditorState, Transaction } from '@codemirror/state';
+import type { AbbreviationContext, UserConfig } from "emmet";
+import type { EditorState, Transaction } from "@codemirror/state";
 
-export type EmmetKnownSyntax = 'html' | 'xml' | 'xsl' | 'jsx' | 'tsx' | 'vue'
-    | 'haml' | 'jade' | 'pug' | 'slim'
-    | 'css' | 'scss' | 'less' | 'sass' | 'sss' | 'stylus' | 'postcss';
+export enum EmmetKnownSyntax {
+  html = "html",
+  xml = "xml",
+  xsl = "xsl",
+  jsx = "jsx",
+  tsx = "tsx",
+  vue = "vue",
+  haml = "haml",
+  jade = "jade",
+  pug = "pug",
+  slim = "slim",
+  css = "css",
+  scss = "scss",
+  less = "less",
+  sass = "sass",
+  sss = "sss",
+  stylus = "stylus",
+  postcss = "postcss",
+}
 
-export type CSSTokenType = 'selector' | 'propertyName' | 'propertyValue';
+export type CSSTokenType = "selector" | "propertyName" | "propertyValue";
 
 export interface RangeObject {
-    from: number;
-    to: number;
+  from: number;
+  to: number;
 }
 
 export interface ContextTag extends AbbreviationContext {
-    open: RangeObject;
-    close?: RangeObject;
+  open: RangeObject;
+  close?: RangeObject;
 }
 
 export interface CSSMatch {
-    /** CSS selector, property or section name */
-    name: string;
-    /** Type of ancestor element */
-    type: CSSTokenType;
-    /** Range of selector or section (just name, not entire block) */
-    range: RangeObject;
+  /** CSS selector, property or section name */
+  name: string;
+  /** Type of ancestor element */
+  type: CSSTokenType;
+  /** Range of selector or section (just name, not entire block) */
+  range: RangeObject;
 }
 
 export interface CSSContext<M = CSSMatch> {
-    type: 'css',
+  type: "css";
 
-    /** List of ancestor sections for current context */
-    ancestors: M[];
+  /** List of ancestor sections for current context */
+  ancestors: M[];
 
-    /** CSS match directly under given position */
-    current: M | null;
+  /** CSS match directly under given position */
+  current: M | null;
 
-    /** Whether CSS context is inline, e.g. in `style=""` HTML attribute */
-    inline: boolean;
+  /** Whether CSS context is inline, e.g. in `style=""` HTML attribute */
+  inline: boolean;
 
-    /**
-     * If current CSS context is embedded into HTML, this property contains
-     * range of CSS source in original content
-     */
-    embedded?: RangeObject;
+  /**
+   * If current CSS context is embedded into HTML, this property contains
+   * range of CSS source in original content
+   */
+  embedded?: RangeObject;
 }
 
-export type HTMLType = 'open' | 'close' | 'selfClose';
+export type HTMLType = "open" | "close" | "selfClose";
 
 export interface HTMLContext {
-    type: 'html',
-    /** List of ancestor elements for current context */
-    ancestors: HTMLAncestor[];
-    /** Tag match directly under given position */
-    current: HTMLMatch | null;
-    /** CSS context, if any */
-    css?: CSSContext;
+  type: "html";
+  /** List of ancestor elements for current context */
+  ancestors: HTMLAncestor[];
+  /** Tag match directly under given position */
+  current: HTMLMatch | null;
+  /** CSS context, if any */
+  css?: CSSContext;
 }
 
 export interface HTMLAncestor {
-    /** Element name */
-    name: string;
-    /** Range of element’s open tag in source code */
-    range: RangeObject;
+  /** Element name */
+  name: string;
+  /** Range of element’s open tag in source code */
+  range: RangeObject;
 }
 
 export interface HTMLMatch {
-    /** Element name */
-    name: string;
-    /** Element type */
-    type: HTMLType;
-    /** Range of matched element in source code */
-    range: RangeObject;
+  /** Element name */
+  name: string;
+  /** Element type */
+  type: HTMLType;
+  /** Range of matched element in source code */
+  range: RangeObject;
 }
 
 export interface StateCommandTarget {
-    state: EditorState;
-    dispatch: (transaction: Transaction) => void;
+  state: EditorState;
+  dispatch: (transaction: Transaction) => void;
 }
 
 export interface AbbreviationError {
-    message: string;
-    pos: number;
+  message: string;
+  pos: number;
 }
 
 export interface StartTrackingParams {
-    config: UserConfig;
-    offset?: number;
-    forced?: boolean;
+  config: UserConfig;
+  offset?: number;
+  forced?: boolean;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-export { default as abbreviationTracker } from './tracker';
+export { default as abbreviationTracker } from "./tracker";
 
 /*
 Emmet commands that should be used as standard CodeMirror commands.
@@ -25,21 +25,27 @@ new EditorView({
 })
 ```
 */
-export { enterAbbreviationMode, emmetCompletionSource } from './tracker';
-export { config as emmetConfig, type EmmetConfig } from './lib/config';
-export type { EmmetKnownSyntax } from './lib/types';
-export { expandAbbreviation } from './commands/expand';
-export { balanceOutward, balanceInward } from './commands/balance';
-export { toggleComment } from './commands/comment';
-export { evaluateMath } from './commands/evaluate-math';
-export { goToNextEditPoint, goToPreviousEditPoint } from './commands/go-to-edit-point';
-export { goToTagPair } from './commands/go-to-tag-pair';
+export { enterAbbreviationMode, emmetCompletionSource } from "./tracker";
+export { config as emmetConfig, type EmmetConfig } from "./lib/config";
+export { EmmetKnownSyntax } from "./lib/types";
+export { expandAbbreviation } from "./commands/expand";
+export { balanceOutward, balanceInward } from "./commands/balance";
+export { toggleComment } from "./commands/comment";
+export { evaluateMath } from "./commands/evaluate-math";
 export {
-    incrementNumber1, decrementNumber1,
-    incrementNumber01, decrementNumber01,
-    incrementNumber10, decrementNumber10
-} from './commands/inc-dec-number';
-export { removeTag } from './commands/remove-tag';
-export { selectNextItem, selectPreviousItem } from './commands/select-item';
-export { splitJoinTag } from './commands/split-join-tag';
-export { wrapWithAbbreviation } from './commands/wrap-with-abbreviation';
+  goToNextEditPoint,
+  goToPreviousEditPoint,
+} from "./commands/go-to-edit-point";
+export { goToTagPair } from "./commands/go-to-tag-pair";
+export {
+  incrementNumber1,
+  decrementNumber1,
+  incrementNumber01,
+  decrementNumber01,
+  incrementNumber10,
+  decrementNumber10,
+} from "./commands/inc-dec-number";
+export { removeTag } from "./commands/remove-tag";
+export { selectNextItem, selectPreviousItem } from "./commands/select-item";
+export { splitJoinTag } from "./commands/split-join-tag";
+export { wrapWithAbbreviation } from "./commands/wrap-with-abbreviation";

--- a/src/tracker/AbbreviationPreviewWidget.ts
+++ b/src/tracker/AbbreviationPreviewWidget.ts
@@ -1,47 +1,55 @@
-import { EditorView } from 'codemirror';
-import { EditorState } from '@codemirror/state';
-import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
-import { html } from '@codemirror/lang-html';
-import { css } from '@codemirror/lang-css';
-import type { EmmetPreviewConfig, PreviewExtensions } from '../lib/config';
+import { EditorView } from "codemirror";
+import { EditorState } from "@codemirror/state";
+import {
+  syntaxHighlighting,
+  defaultHighlightStyle,
+} from "@codemirror/language";
+import { html } from "@codemirror/lang-html";
+import { css } from "@codemirror/lang-css";
+import type { EmmetPreviewConfig, PreviewExtensions } from "../lib/config";
+import { EmmetKnownSyntax } from "../plugin";
 
 export interface HTMLElementPreview extends HTMLElement {
-    update?: (value: string) => void;
+  update?: (value: string) => void;
 }
 
-export function createPreview(value: string, syntax: string, options?: EmmetPreviewConfig): HTMLElementPreview {
-    const elem = document.createElement('div') as HTMLElementPreview;
-    elem.className = 'emmet-preview';
-    if (syntax === 'error') {
-        elem.classList.add('emmet-preview_error');
-    }
+export function createPreview(
+  value: string,
+  syntax: string,
+  options?: EmmetPreviewConfig
+): HTMLElementPreview {
+  const elem = document.createElement("div") as HTMLElementPreview;
+  elem.className = "emmet-preview";
+  if (syntax === "error") {
+    elem.classList.add("emmet-preview_error");
+  }
 
-    let ext: PreviewExtensions = syntax === 'css' ? css : html;
-    if (options && syntax in options) {
-        ext = options[syntax as keyof EmmetPreviewConfig]!;
-    }
+  let ext: PreviewExtensions = syntax === EmmetKnownSyntax.css ? css : html;
+  if (options && syntax in options) {
+    ext = options[syntax as keyof EmmetPreviewConfig]!;
+  }
 
-    const view = new EditorView({
-        doc: value,
-        extensions: [
-            EditorState.readOnly.of(true),
-            syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-            syntax === 'css' ? css() : html(),
-            ext()
-        ],
-        parent: elem
+  const view = new EditorView({
+    doc: value,
+    extensions: [
+      EditorState.readOnly.of(true),
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      syntax === "css" ? css() : html(),
+      ext(),
+    ],
+    parent: elem,
+  });
+
+  elem.update = (nextValue) => {
+    const tr = view.state.update({
+      changes: {
+        from: 0,
+        to: view.state.doc.length,
+        insert: nextValue,
+      },
     });
+    view.dispatch(tr);
+  };
 
-    elem.update = (nextValue) => {
-        const tr = view.state.update({
-            changes: {
-                from: 0,
-                to: view.state.doc.length,
-                insert: nextValue
-            }
-        });
-        view.dispatch(tr);
-    };
-
-    return elem;
+  return elem;
 }

--- a/src/tracker/index.ts
+++ b/src/tracker/index.ts
@@ -1,31 +1,76 @@
-import type { MarkupAbbreviation, StylesheetAbbreviation, UserConfig } from 'emmet';
-import { markupAbbreviation } from 'emmet';
-import { ViewPlugin, Decoration, keymap, EditorView, type Tooltip, showTooltip } from '@codemirror/view';
-import type { DecorationSet, Command, ViewUpdate } from '@codemirror/view';
-import { StateEffect, StateField } from '@codemirror/state';
-import type { Range, EditorState, Extension, StateCommand, Transaction } from '@codemirror/state';
-import { htmlLanguage } from '@codemirror/lang-html';
-import { cssLanguage } from '@codemirror/lang-css';
-import { snippet, pickedCompletion, completionStatus, type CompletionResult, type Completion } from '@codemirror/autocomplete';
-import type { CompletionSource } from '@codemirror/autocomplete';
-import { getCSSContext, getHTMLContext } from '../lib/context';
-import { docSyntax, getMarkupAbbreviationContext, getStylesheetAbbreviationContext, getSyntaxType, isCSS, isHTML, isJSX, isSupported } from '../lib/syntax';
-import getOutputOptions from '../lib/output';
-import type { CSSContext, AbbreviationError, StartTrackingParams, RangeObject } from '../lib/types';
-import { contains, getCaret, rangeEmpty, substr } from '../lib/utils';
-import { expand } from '../lib/emmet';
-import { type HTMLElementPreview, createPreview } from './AbbreviationPreviewWidget';
-import icon from '../completion-icon.svg';
-import getEmmetConfig, { config, type EmmetPreviewConfig, type EmmetConfig } from '../lib/config';
+import type {
+  MarkupAbbreviation,
+  StylesheetAbbreviation,
+  UserConfig,
+} from "emmet";
+import { markupAbbreviation } from "emmet";
+import {
+  ViewPlugin,
+  Decoration,
+  keymap,
+  EditorView,
+  type Tooltip,
+  showTooltip,
+} from "@codemirror/view";
+import type { DecorationSet, Command, ViewUpdate } from "@codemirror/view";
+import { StateEffect, StateField } from "@codemirror/state";
+import type {
+  Range,
+  EditorState,
+  Extension,
+  StateCommand,
+  Transaction,
+} from "@codemirror/state";
+import { htmlLanguage } from "@codemirror/lang-html";
+import { cssLanguage } from "@codemirror/lang-css";
+import {
+  snippet,
+  pickedCompletion,
+  completionStatus,
+  type CompletionResult,
+  type Completion,
+} from "@codemirror/autocomplete";
+import type { CompletionSource } from "@codemirror/autocomplete";
+import { getCSSContext, getHTMLContext } from "../lib/context";
+import {
+  docSyntax,
+  getMarkupAbbreviationContext,
+  getStylesheetAbbreviationContext,
+  getSyntaxType,
+  isCSS,
+  isHTML,
+  isJSX,
+  isSupported,
+} from "../lib/syntax";
+import getOutputOptions from "../lib/output";
+import {
+  type CSSContext,
+  type AbbreviationError,
+  type StartTrackingParams,
+  type RangeObject,
+  EmmetKnownSyntax,
+} from "../lib/types";
+import { contains, getCaret, rangeEmpty, substr } from "../lib/utils";
+import { expand } from "../lib/emmet";
+import {
+  type HTMLElementPreview,
+  createPreview,
+} from "./AbbreviationPreviewWidget";
+import icon from "../completion-icon.svg";
+import getEmmetConfig, {
+  config,
+  type EmmetPreviewConfig,
+  type EmmetConfig,
+} from "../lib/config";
 
 interface EmmetCompletion extends Completion {
-    tracker: AbbreviationTrackerValid;
-    previewConfig: EmmetPreviewConfig;
-    preview?: HTMLElementPreview;
+  tracker: AbbreviationTrackerValid;
+  previewConfig: EmmetPreviewConfig;
+  preview?: HTMLElementPreview;
 }
 
 interface EmmetTooltip extends Tooltip {
-    tracker: AbbreviationTracker;
+  tracker: AbbreviationTracker;
 }
 
 type AbbreviationTracker = AbbreviationTrackerValid | AbbreviationTrackerError;
@@ -37,279 +82,299 @@ type AbbreviationTracker = AbbreviationTrackerValid | AbbreviationTrackerError;
 // Текущая реализация укладывается в нужную концепцию,
 // но проверка автокомплита обрабатывается раньше, чем обновляется трэкер.
 // Нужно найти способ обновить трэкер раньше, чем отработает код автокомплита
-export const emmetCompletionSource: CompletionSource = context => {
-    const tracker = context.state.field(trackerField);
-    if (tracker?.type === 'abbreviation' && tracker.preview) {
+export const emmetCompletionSource: CompletionSource = (context) => {
+  const tracker = context.state.field(trackerField);
+  if (tracker?.type === "abbreviation" && tracker.preview) {
+    return {
+      from: tracker.range.from,
+      to: tracker.range.to,
+      filter: false,
+      update(current, _from, _to, context) {
+        const tracker = context.state.field(trackerField);
+        if (!tracker || tracker.type === "error") {
+          return null;
+        }
+
         return {
-            from: tracker.range.from,
-            to: tracker.range.to,
-            filter: false,
-            update(current, _from, _to, context) {
-                const tracker = context.state.field(trackerField);
-                if (!tracker || tracker.type === 'error') {
-                    return null;
-                }
+          ...current,
+          from: tracker.range.from,
+          to: tracker.range.to,
+          options: completionOptionsFromTracker(context.state, tracker),
+        };
+      },
+      options: completionOptionsFromTracker(context.state, tracker),
+    } as CompletionResult;
+  }
 
-                return {
-                    ...current,
-                    from: tracker.range.from,
-                    to: tracker.range.to,
-                    options: completionOptionsFromTracker(context.state, tracker)
-                };
-            },
-            options: completionOptionsFromTracker(context.state, tracker)
-        } as CompletionResult;
-    }
+  return null;
+};
 
-    return null;
-}
-
-const cssCompletion: Extension = cssLanguage.data.of({ autocomplete: emmetCompletionSource });
+const cssCompletion: Extension = cssLanguage.data.of({
+  autocomplete: emmetCompletionSource,
+});
 
 interface AbbreviationTrackerBase {
-    /** Range in editor for abbreviation */
-    range: RangeObject;
+  /** Range in editor for abbreviation */
+  range: RangeObject;
 
-    /** Actual abbreviation, tracked by current tracker */
-    abbreviation: string;
+  /** Actual abbreviation, tracked by current tracker */
+  abbreviation: string;
 
-    /**
-     * Abbreviation was forced, e.g. must remain in editor even if empty or contains
-     * invalid abbreviation
-     */
-    forced: boolean;
+  /**
+   * Abbreviation was forced, e.g. must remain in editor even if empty or contains
+   * invalid abbreviation
+   */
+  forced: boolean;
 
-    /** Indicates that current tracker shouldn’t be displayed in editor */
-    inactive: boolean;
+  /** Indicates that current tracker shouldn’t be displayed in editor */
+  inactive: boolean;
 
-    /**
-     * Relative offset from range start where actual abbreviation starts.
-     * Used tp handle prefixes in abbreviation
-     */
-    offset: number;
+  /**
+   * Relative offset from range start where actual abbreviation starts.
+   * Used tp handle prefixes in abbreviation
+   */
+  offset: number;
 
-    config: UserConfig;
+  config: UserConfig;
 }
 
 export interface AbbreviationTrackerValid extends AbbreviationTrackerBase {
-    type: 'abbreviation';
+  type: "abbreviation";
 
-    /**
-     * Abbreviation is simple, e.g. contains single element.
-     * It’s suggested to not display preview for simple abbreviation
-     */
-    simple: boolean;
+  /**
+   * Abbreviation is simple, e.g. contains single element.
+   * It’s suggested to not display preview for simple abbreviation
+   */
+  simple: boolean;
 
-    /** Preview of expanded abbreviation */
-    preview: string;
+  /** Preview of expanded abbreviation */
+  preview: string;
 }
 
 export interface AbbreviationTrackerError extends AbbreviationTrackerBase {
-    type: 'error';
-    error: AbbreviationError;
+  type: "error";
+  error: AbbreviationError;
 }
 
-export const JSX_PREFIX = '<';
+export const JSX_PREFIX = "<";
 
-const trackerMark = Decoration.mark({ class: 'emmet-tracker' });
+const trackerMark = Decoration.mark({ class: "emmet-tracker" });
 
 const resetTracker = StateEffect.define();
 const forceTracker = StateEffect.define();
 
 export const enterAbbreviationMode: StateCommand = ({ state, dispatch }) => {
-    const tr = state.update({
-        effects: [forceTracker.of(null)]
-    });
-    dispatch(tr);
-    return true;
+  const tr = state.update({
+    effects: [forceTracker.of(null)],
+  });
+  dispatch(tr);
+  return true;
 };
 
 const trackerField = StateField.define<AbbreviationTracker | null>({
-    create: () => null,
-    update(value, tr) {
-        const hasCompletion = tr.annotation(pickedCompletion);
-        if (hasCompletion) {
-            // When completion is applied, always reset tracker
-            return null;
-        }
-
-        for (const effect of tr.effects) {
-            if (effect.is(resetTracker)) {
-                return null;
-            }
-
-            if (effect.is(forceTracker)) {
-                const sel = tr.newSelection.main;
-                const config = getActivationContext(tr.state, sel.from);
-                if (config) {
-                    return createTracker(tr.state, sel, {
-                        forced: true,
-                        config
-                    });
-                }
-            }
-        }
-
-        if (!tr.docChanged) {
-            return value;
-        }
-        return handleUpdate(tr.state, value, tr);
+  create: () => null,
+  update(value, tr) {
+    const hasCompletion = tr.annotation(pickedCompletion);
+    if (hasCompletion) {
+      // When completion is applied, always reset tracker
+      return null;
     }
+
+    for (const effect of tr.effects) {
+      if (effect.is(resetTracker)) {
+        return null;
+      }
+
+      if (effect.is(forceTracker)) {
+        const sel = tr.newSelection.main;
+        const config = getActivationContext(tr.state, sel.from);
+        if (config) {
+          return createTracker(tr.state, sel, {
+            forced: true,
+            config,
+          });
+        }
+      }
+    }
+
+    if (!tr.docChanged) {
+      return value;
+    }
+    return handleUpdate(tr.state, value, tr);
+  },
 });
 
 const abbreviationPreview = StateField.define<EmmetTooltip | null>({
-    create: getAbbreviationPreview,
-    update(tooltip, tr) {
-        if (!tr.docChanged && !tr.selection) {
-            const tracker = tr.state.field(trackerField);
-            return tracker ? tooltip : null;
-        }
-        return getAbbreviationPreview(tr.state, tooltip);
-    },
-    provide: f => showTooltip.from(f)
+  create: getAbbreviationPreview,
+  update(tooltip, tr) {
+    if (!tr.docChanged && !tr.selection) {
+      const tracker = tr.state.field(trackerField);
+      return tracker ? tooltip : null;
+    }
+    return getAbbreviationPreview(tr.state, tooltip);
+  },
+  provide: (f) => showTooltip.from(f),
 });
 
-function getAbbreviationPreview(state: EditorState, prevTooltip?: EmmetTooltip | null): EmmetTooltip | null {
-    const tracker = state.field(trackerField);
+function getAbbreviationPreview(
+  state: EditorState,
+  prevTooltip?: EmmetTooltip | null
+): EmmetTooltip | null {
+  const tracker = state.field(trackerField);
 
-    if (tracker && !tracker.inactive && completionStatus(state) !== 'active') {
-        if (tracker.config.type === 'stylesheet') {
-            // Do not display preview for CSS since completions are populated
-            // automatically for this syntax and abbreviation will be a part of
-            // completion list
-            return null;
-        }
-
-        if (prevTooltip && prevTooltip.tracker.type !== tracker.type) {
-            prevTooltip = null;
-        }
-
-        const { range } = tracker;
-
-        if (canDisplayPreview(state, tracker)) {
-            return prevTooltip || {
-                pos: range.from,
-                above: false,
-                arrow: false,
-                tracker,
-                create() {
-                    const previewConfig = state.facet(config).preview;
-                    let preview = '';
-                    let syntax = '';
-
-                    if (tracker.type === 'error') {
-                        preview = tracker.error.message;
-                        syntax = 'error';
-                    } else {
-                        preview = tracker.preview;
-                        syntax = tracker.config.syntax || 'html';
-                    }
-
-                    const dom = createPreview(preview, syntax, previewConfig);
-                    return {
-                        dom,
-                        update({ state }) {
-                            const tracker = state.field(trackerField);
-                            if (tracker && dom.update) {
-                                const value = tracker.type === 'error'
-                                    ? tracker.error.message
-                                    : tracker.preview;
-                                dom.update(value);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+  if (tracker && !tracker.inactive && completionStatus(state) !== "active") {
+    if (tracker.config.type === "stylesheet") {
+      // Do not display preview for CSS since completions are populated
+      // automatically for this syntax and abbreviation will be a part of
+      // completion list
+      return null;
     }
 
-    return null;
+    if (prevTooltip && prevTooltip.tracker.type !== tracker.type) {
+      prevTooltip = null;
+    }
+
+    const { range } = tracker;
+
+    if (canDisplayPreview(state, tracker)) {
+      return (
+        prevTooltip || {
+          pos: range.from,
+          above: false,
+          arrow: false,
+          tracker,
+          create() {
+            const previewConfig = state.facet(config).preview;
+            let preview = "";
+            let syntax = "";
+
+            if (tracker.type === "error") {
+              preview = tracker.error.message;
+              syntax = "error";
+            } else {
+              preview = tracker.preview;
+              syntax = tracker.config.syntax || EmmetKnownSyntax.html;
+            }
+
+            const dom = createPreview(preview, syntax, previewConfig);
+            return {
+              dom,
+              update({ state }) {
+                const tracker = state.field(trackerField);
+                if (tracker && dom.update) {
+                  const value =
+                    tracker.type === "error"
+                      ? tracker.error.message
+                      : tracker.preview;
+                  dom.update(value);
+                }
+              },
+            };
+          },
+        }
+      );
+    }
+  }
+
+  return null;
 }
 
-const abbreviationTracker = ViewPlugin.fromClass(class {
+const abbreviationTracker = ViewPlugin.fromClass(
+  class {
     decorations: DecorationSet;
 
     constructor() {
-        this.decorations = Decoration.none;
+      this.decorations = Decoration.none;
     }
 
     update(update: ViewUpdate) {
-        const { state } = update;
+      const { state } = update;
 
-        const tracker = state.field(trackerField);
-        const decors: Range<Decoration>[] = [];
+      const tracker = state.field(trackerField);
+      const decors: Range<Decoration>[] = [];
 
-        if (tracker && !tracker.inactive) {
-            const { range } = tracker;
+      if (tracker && !tracker.inactive) {
+        const { range } = tracker;
 
-            if (!rangeEmpty(range) ) {
-                decors.push(trackerMark.range(range.from, range.to));
-            }
-            this.decorations = Decoration.set(decors, true);
-        } else {
-            this.decorations = Decoration.none;
+        if (!rangeEmpty(range)) {
+          decors.push(trackerMark.range(range.from, range.to));
         }
+        this.decorations = Decoration.set(decors, true);
+      } else {
+        this.decorations = Decoration.none;
+      }
     }
-}, {
-    decorations: v => v.decorations,
-});
+  },
+  {
+    decorations: (v) => v.decorations,
+  }
+);
 
-export function expandTracker(view: EditorView, tracker: AbbreviationTracker): void {
-    const { from, to } = tracker.range;
-    const expanded = expand(view.state, tracker.abbreviation, tracker.config);
-    const fn = snippet(expanded);
+export function expandTracker(
+  view: EditorView,
+  tracker: AbbreviationTracker
+): void {
+  const { from, to } = tracker.range;
+  const expanded = expand(view.state, tracker.abbreviation, tracker.config);
+  const fn = snippet(expanded);
 
-    view.dispatch(view.state.update({
-        effects: resetTracker.of(null)
-    }));
-    fn(view, { label: 'expand' }, from, to);
+  view.dispatch(
+    view.state.update({
+      effects: resetTracker.of(null),
+    })
+  );
+  fn(view, { label: "expand" }, from, to);
 }
 
 const tabKeyHandler: Command = (view) => {
-    const { state } = view;
-    if (completionStatus(state)) {
-        // Must be handled by `acceptCompletion` command
-        return false;
-    }
-
-    const tracker = state.field(trackerField, false);
-    if (tracker && !tracker.inactive && contains(tracker.range, getCaret(state))) {
-        expandTracker(view, tracker);
-        return true;
-    }
+  const { state } = view;
+  if (completionStatus(state)) {
+    // Must be handled by `acceptCompletion` command
     return false;
+  }
+
+  const tracker = state.field(trackerField, false);
+  if (
+    tracker &&
+    !tracker.inactive &&
+    contains(tracker.range, getCaret(state))
+  ) {
+    expandTracker(view, tracker);
+    return true;
+  }
+  return false;
 };
 
 const escKeyHandler: Command = ({ state, dispatch }) => {
-    const tracker = state.field(trackerField, false);
-    if (tracker) {
-        dispatch({
-            effects: resetTracker.of(null)
-        });
-        return true;
-    }
+  const tracker = state.field(trackerField, false);
+  if (tracker) {
+    dispatch({
+      effects: resetTracker.of(null),
+    });
+    return true;
+  }
 
-    return false;
+  return false;
 };
 
 const trackerTheme = EditorView.baseTheme({
-    '.emmet-tracker': {
-        textDecoration: 'underline 1px green',
-    },
-    '.emmet-preview': {
-        fontSize: '0.9em'
-    },
-    '.emmet-preview_error': {
-        color: 'red'
-    },
-    '.cm-completionIcon-emmet::after': {
-        content: '" "',
-        background: `url("${icon}") center/contain no-repeat`,
-        display: 'inline-block',
-        width: '11px',
-        height: '11px',
-        verticalAlign: 'middle'
-    }
+  ".emmet-tracker": {
+    textDecoration: "underline 1px green",
+  },
+  ".emmet-preview": {
+    fontSize: "0.9em",
+  },
+  ".emmet-preview_error": {
+    color: "red",
+  },
+  ".cm-completionIcon-emmet::after": {
+    content: '" "',
+    background: `url("${icon}") center/contain no-repeat`,
+    display: "inline-block",
+    width: "11px",
+    height: "11px",
+    verticalAlign: "middle",
+  },
 });
 
 /**
@@ -320,30 +385,33 @@ const trackerTheme = EditorView.baseTheme({
  * press Escape key to reset tracker
  */
 export default function tracker(options?: Partial<EmmetConfig>): Extension[] {
-    return [
-        trackerField,
-        abbreviationTracker,
-        abbreviationPreview,
-        trackerTheme,
-        cssCompletion,
-        options ? config.of(options) : [],
-        keymap.of([{
-            key: 'Tab',
-            run: tabKeyHandler
-        }, {
-            key: 'Escape',
-            run: escKeyHandler
-        }])
-    ]
+  return [
+    trackerField,
+    abbreviationTracker,
+    abbreviationPreview,
+    trackerTheme,
+    cssCompletion,
+    options ? config.of(options) : [],
+    keymap.of([
+      {
+        key: "Tab",
+        run: tabKeyHandler,
+      },
+      {
+        key: "Escape",
+        run: escKeyHandler,
+      },
+    ]),
+  ];
 }
 
-export { resetTracker as trackerResetAction }
+export { resetTracker as trackerResetAction };
 
 /**
  * Check if abbreviation tracking is allowed in editor at given location
  */
 export function allowTracking(state: EditorState): boolean {
-    return isSupported(docSyntax(state));
+  return isSupported(docSyntax(state));
 }
 
 /**
@@ -351,45 +419,52 @@ export function allowTracking(state: EditorState): boolean {
  * @param pos Location where user started typing
  * @param input Text entered at `pos` location
  */
-function typingAbbreviation(state: EditorState, pos: number, input: string): AbbreviationTracker | null {
-    if (input.length !== 1) {
-        // Expect single character enter to start abbreviation tracking
-        return null;
-    }
+function typingAbbreviation(
+  state: EditorState,
+  pos: number,
+  input: string
+): AbbreviationTracker | null {
+  if (input.length !== 1) {
+    // Expect single character enter to start abbreviation tracking
+    return null;
+  }
 
-    // Start tracking only if user starts abbreviation typing: entered first
-    // character at the word bound
-    const line = state.doc.lineAt(pos);
-    const prefix = line.text.substring(Math.max(0, pos - line.from - 1), pos - line.from);
+  // Start tracking only if user starts abbreviation typing: entered first
+  // character at the word bound
+  const line = state.doc.lineAt(pos);
+  const prefix = line.text.substring(
+    Math.max(0, pos - line.from - 1),
+    pos - line.from
+  );
 
-    // Check if current syntax is supported for tracking
-    if (!canStartTyping(prefix, input, getSyntaxFromPos(state, pos))) {
-        return null;
-    }
+  // Check if current syntax is supported for tracking
+  if (!canStartTyping(prefix, input, getSyntaxFromPos(state, pos))) {
+    return null;
+  }
 
-    const config = getActivationContext(state, pos);
-    if (!config) {
-        return null;
-    }
+  const config = getActivationContext(state, pos);
+  if (!config) {
+    return null;
+  }
 
-    if (config.type === 'stylesheet' && !canStartTyping(prefix, input, 'css')) {
-        // Additional check for stylesheet abbreviation start: it’s slightly
-        // differs from markup prefix, but we need activation context
-        // to ensure that context under caret is CSS
-        return null;
-    }
+  if (config.type === "stylesheet" && !canStartTyping(prefix, input, "css")) {
+    // Additional check for stylesheet abbreviation start: it’s slightly
+    // differs from markup prefix, but we need activation context
+    // to ensure that context under caret is CSS
+    return null;
+  }
 
-    const syntax = config.syntax || 'html';
-    let from = pos;
-    let to = pos + input.length;
-    let offset = 0;
+  const syntax = config.syntax || "html";
+  let from = pos;
+  let to = pos + input.length;
+  let offset = 0;
 
-    if (isJSX(syntax) && prefix === JSX_PREFIX) {
-        offset = JSX_PREFIX.length;
-        from -= offset;
-    }
+  if (isJSX(syntax) && prefix === JSX_PREFIX) {
+    offset = JSX_PREFIX.length;
+    from -= offset;
+  }
 
-    return createTracker(state, { from, to }, { config });
+  return createTracker(state, { from, to }, { config });
 }
 
 /**
@@ -403,55 +478,69 @@ function typingAbbreviation(state: EditorState, pos: number, input: string): Abb
  * This method ensures that given `pos` is inside location allowed for expanding
  * abbreviations and returns context data about it.
  */
-export function getActivationContext(state: EditorState, pos: number): UserConfig | undefined {
-    if (cssLanguage.isActiveAt(state, pos)) {
-        return getCSSActivationContext(state, pos, 'css', getCSSContext(state, pos));
+export function getActivationContext(
+  state: EditorState,
+  pos: number
+): UserConfig | undefined {
+  if (cssLanguage.isActiveAt(state, pos)) {
+    return getCSSActivationContext(
+      state,
+      pos,
+      "css",
+      getCSSContext(state, pos)
+    );
+  }
+
+  const syntax = docSyntax(state);
+
+  if (isHTML(syntax)) {
+    const ctx = getHTMLContext(state, pos);
+
+    if (ctx.css) {
+      return getCSSActivationContext(state, pos, "css", ctx.css);
     }
 
-    const syntax = docSyntax(state);
-
-    if (isHTML(syntax)) {
-        const ctx = getHTMLContext(state, pos);
-
-        if (ctx.css) {
-            return getCSSActivationContext(state, pos, 'css', ctx.css);
-        }
-
-        if (!ctx.current) {
-            return {
-                syntax,
-                type: 'markup',
-                context: getMarkupAbbreviationContext(state, ctx),
-                options: getOutputOptions(state)
-            };
-        }
-    } else {
-        return {
-            syntax,
-            type: getSyntaxType(syntax),
-            options: getOutputOptions(state)
-        };
+    if (!ctx.current) {
+      return {
+        syntax,
+        type: "markup",
+        context: getMarkupAbbreviationContext(state, ctx),
+        options: getOutputOptions(state),
+      };
     }
+  } else {
+    return {
+      syntax,
+      type: getSyntaxType(syntax),
+      options: getOutputOptions(state),
+    };
+  }
 
-    return undefined;
+  return undefined;
 }
 
-function getCSSActivationContext(state: EditorState, pos: number, syntax: string, ctx: CSSContext): UserConfig | undefined {
-    const allowedContext = !ctx.current
-        || ctx.current.type === 'propertyName'
-        || ctx.current.type === 'propertyValue'
-        || isTypingBeforeSelector(state, pos, ctx);
+function getCSSActivationContext(
+  state: EditorState,
+  pos: number,
+  syntax: string,
+  ctx: CSSContext
+): UserConfig | undefined {
+  const allowedContext =
+    !ctx.current ||
+    ctx.current.type === "propertyName" ||
+    ctx.current.type === "propertyValue" ||
+    isTypingBeforeSelector(state, pos, ctx);
 
-    if (allowedContext) {
-        return {
-            syntax,
-            type: 'stylesheet',
-            context: getStylesheetAbbreviationContext(ctx),
-            options: getOutputOptions(state, ctx.inline)
-        };
-    }
+  if (allowedContext) {
+    return {
+      syntax,
+      type: "stylesheet",
+      context: getStylesheetAbbreviationContext(ctx),
+      options: getOutputOptions(state, ctx.inline),
+    };
+  }
 
-    return;
+  return;
 }
 
 /**
@@ -459,39 +548,43 @@ function getCSSActivationContext(state: EditorState, pos: number, syntax: string
  * entered character becomes part of selector
  * Activate only if it’s a nested section and it’s a first character of selector
  */
-function isTypingBeforeSelector(state: EditorState, pos: number, { current }: CSSContext): boolean {
-    if (current?.type === 'selector' && current.range.from === pos - 1) {
-        // Typing abbreviation before selector is tricky one:
-        // ensure it’s on its own line
-        const line = state.doc.lineAt(current.range.from);
-        return line.text.trim().length === 1;
-    }
+function isTypingBeforeSelector(
+  state: EditorState,
+  pos: number,
+  { current }: CSSContext
+): boolean {
+  if (current?.type === "selector" && current.range.from === pos - 1) {
+    // Typing abbreviation before selector is tricky one:
+    // ensure it’s on its own line
+    const line = state.doc.lineAt(current.range.from);
+    return line.text.trim().length === 1;
+  }
 
-    return false;
+  return false;
 }
 
 function isValidPrefix(prefix: string, syntax: string): boolean {
-    if (isJSX(syntax)) {
-        return prefix === JSX_PREFIX;
-    }
+  if (isJSX(syntax)) {
+    return prefix === JSX_PREFIX;
+  }
 
-    if (isCSS(syntax)) {
-        return prefix === '' || /^[\s>;"\']$/.test(prefix);
-    }
+  if (isCSS(syntax)) {
+    return prefix === "" || /^[\s>;"\']$/.test(prefix);
+  }
 
-    return prefix === '' || /^[\s>;"\']$/.test(prefix);
+  return prefix === "" || /^[\s>;"\']$/.test(prefix);
 }
 
 function isValidAbbreviationStart(input: string, syntax: string): boolean {
-    if (isJSX(syntax)) {
-        return /^[a-zA-Z.#\[\(]$/.test(input);
-    }
+  if (isJSX(syntax)) {
+    return /^[a-zA-Z.#\[\(]$/.test(input);
+  }
 
-    if (isCSS(syntax)) {
-        return /^[a-zA-Z!@#]$/.test(input);
-    }
+  if (isCSS(syntax)) {
+    return /^[a-zA-Z!@#]$/.test(input);
+  }
 
-    return /^[a-zA-Z.#!@\[\(]$/.test(input);
+  return /^[a-zA-Z.#!@\[\(]$/.test(input);
 }
 
 /**
@@ -499,69 +592,75 @@ function isValidAbbreviationStart(input: string, syntax: string): boolean {
  * of abbreviation in range and returns either valid abbreviation tracker,
  * error tracker or `null` if abbreviation cannot be created from given range
  */
-function createTracker(state: EditorState, range: RangeObject, params: StartTrackingParams): AbbreviationTracker | null {
-    if (range.from > range.to) {
-        // Invalid range
-        return null;
+function createTracker(
+  state: EditorState,
+  range: RangeObject,
+  params: StartTrackingParams
+): AbbreviationTracker | null {
+  if (range.from > range.to) {
+    // Invalid range
+    return null;
+  }
+
+  let abbreviation = substr(state, range);
+  const { config, forced } = params;
+  if (params.offset) {
+    abbreviation = abbreviation.slice(params.offset);
+  }
+
+  // Basic validation: do not allow empty abbreviations
+  // or newlines in abbreviations
+  if ((!abbreviation && !forced) || hasInvalidChars(abbreviation)) {
+    return null;
+  }
+
+  const base: AbbreviationTrackerBase = {
+    abbreviation,
+    range,
+    config,
+    forced: !!forced,
+    inactive: false,
+    offset: params.offset || 0,
+  };
+
+  try {
+    let parsedAbbr: MarkupAbbreviation | StylesheetAbbreviation | undefined;
+    let simple = false;
+
+    if (config.type === "markup") {
+      parsedAbbr = markupAbbreviation(abbreviation, {
+        jsx: config.syntax === EmmetKnownSyntax.jsx,
+      });
+      simple = isSimpleMarkupAbbreviation(parsedAbbr);
     }
 
-    let abbreviation = substr(state, range);
-    const { config, forced } = params;
-    if (params.offset) {
-        abbreviation = abbreviation.slice(params.offset);
+    const previewConfig = createPreviewConfig(config);
+    const preview = expand(state, parsedAbbr || abbreviation, previewConfig);
+    if (!preview) {
+      // Handle edge case: abbreviation didn’t return any result for preview.
+      // Most likely it means a CSS context where given abbreviation is not applicable
+      return null;
     }
 
-    // Basic validation: do not allow empty abbreviations
-    // or newlines in abbreviations
-    if ((!abbreviation && !forced) || hasInvalidChars(abbreviation)) {
-        return null;
-    }
-
-    const base: AbbreviationTrackerBase = {
-        abbreviation,
-        range,
-        config,
-        forced: !!forced,
-        inactive: false,
-        offset: params.offset || 0,
-    }
-
-    try {
-        let parsedAbbr: MarkupAbbreviation | StylesheetAbbreviation | undefined;
-        let simple = false;
-
-        if (config.type === 'markup') {
-            parsedAbbr = markupAbbreviation(abbreviation, {
-                jsx: config.syntax === 'jsx'
-            });
-            simple = isSimpleMarkupAbbreviation(parsedAbbr);
+    return {
+      ...base,
+      type: "abbreviation",
+      simple,
+      preview,
+    };
+  } catch (error) {
+    return base.forced
+      ? {
+          ...base,
+          type: "error",
+          error: error as AbbreviationError,
         }
-
-        const previewConfig = createPreviewConfig(config);
-        const preview = expand(state, parsedAbbr || abbreviation, previewConfig);
-        if (!preview) {
-            // Handle edge case: abbreviation didn’t return any result for preview.
-            // Most likely it means a CSS context where given abbreviation is not applicable
-            return null;
-        }
-
-        return {
-            ...base,
-            type: 'abbreviation',
-            simple,
-            preview,
-        };
-    } catch (error) {
-        return base.forced ? {
-            ...base,
-            type: 'error',
-            error: error as AbbreviationError,
-        } : null;
-    }
+      : null;
+  }
 }
 
 function hasInvalidChars(abbreviation: string): boolean {
-    return /[\r\n]/.test(abbreviation);
+  return /[\r\n]/.test(abbreviation);
 }
 
 /**
@@ -569,104 +668,110 @@ function hasInvalidChars(abbreviation: string): boolean {
  * may not be displayed to user as preview to reduce distraction
  */
 function isSimpleMarkupAbbreviation(abbr: MarkupAbbreviation): boolean {
-    if (abbr.children.length === 1 && !abbr.children[0].children.length) {
-        // Single element: might be a HTML element or text snippet
-        const first = abbr.children[0];
-        // XXX silly check for common snippets like `!`. Should read contents
-        // of expanded abbreviation instead
-        return !first.name || /^[a-z]/i.test(first.name);
-    }
-    return !abbr.children.length;
+  if (abbr.children.length === 1 && !abbr.children[0].children.length) {
+    // Single element: might be a HTML element or text snippet
+    const first = abbr.children[0];
+    // XXX silly check for common snippets like `!`. Should read contents
+    // of expanded abbreviation instead
+    return !first.name || /^[a-z]/i.test(first.name);
+  }
+  return !abbr.children.length;
 }
 
 function createPreviewConfig(config: UserConfig) {
-    return {
-        ...config,
-        options: {
-            ...config.options,
-            'output.field': previewField,
-            'output.indent': '  ',
-            'output.baseIndent': ''
-        }
-    };
+  return {
+    ...config,
+    options: {
+      ...config.options,
+      "output.field": previewField,
+      "output.indent": "  ",
+      "output.baseIndent": "",
+    },
+  };
 }
 
 function previewField(_: number, placeholder: string) {
-    return placeholder;
+  return placeholder;
 }
 
-function handleUpdate(state: EditorState, tracker: AbbreviationTracker | null, update: Transaction): AbbreviationTracker | null {
-    if (hasSnippet(state)) {
-        return null;
-    }
+function handleUpdate(
+  state: EditorState,
+  tracker: AbbreviationTracker | null,
+  update: Transaction
+): AbbreviationTracker | null {
+  if (hasSnippet(state)) {
+    return null;
+  }
 
-    if (!tracker || tracker.inactive) {
-        // Start abbreviation tracking
-        update.changes.iterChanges((_fromA, _toA, fromB, _toB, text) => {
-            if (text.length) {
-                tracker = typingAbbreviation(state, fromB, text.toString()) || tracker;
-            }
-        });
-
-        if (!tracker || !tracker.inactive) {
-            return tracker;
-        }
-    }
-
-    // Continue abbreviation tracking
-    update.changes.iterChanges((fromA, toA, fromB, toB, text) => {
-        if (!tracker) {
-            return;
-        }
-
-        const { range } = tracker;
-        if (!contains(range, fromA)) {
-            // Update is outside of abbreviation, reset it only if it’s not inactive
-            if (!tracker.inactive) {
-                tracker = null;
-            }
-        } else if (contains(range, fromB)) {
-            const removed = toA - fromA;
-            const inserted = toB - fromA;
-            const to = range.to + inserted - removed;
-            if (to <= range.from || hasInvalidChars(text.toString())) {
-                tracker = null;
-            } else {
-                const abbrRange = tracker.inactive ? range : { from: range.from, to };
-                const nextTracker = createTracker(state, abbrRange, {
-                    config: tracker.config,
-                    forced: tracker.forced
-                });
-
-                if (!nextTracker) {
-                    // Next tracker is empty mostly due to invalid abbreviation.
-                    // To allow users to fix error, keep previous tracker
-                    // instance as inactive
-                    tracker = { ...tracker, inactive: true };
-                } else {
-                    tracker = nextTracker;
-                }
-            }
-        }
+  if (!tracker || tracker.inactive) {
+    // Start abbreviation tracking
+    update.changes.iterChanges((_fromA, _toA, fromB, _toB, text) => {
+      if (text.length) {
+        tracker = typingAbbreviation(state, fromB, text.toString()) || tracker;
+      }
     });
 
-    return tracker;
+    if (!tracker || !tracker.inactive) {
+      return tracker;
+    }
+  }
+
+  // Continue abbreviation tracking
+  update.changes.iterChanges((fromA, toA, fromB, toB, text) => {
+    if (!tracker) {
+      return;
+    }
+
+    const { range } = tracker;
+    if (!contains(range, fromA)) {
+      // Update is outside of abbreviation, reset it only if it’s not inactive
+      if (!tracker.inactive) {
+        tracker = null;
+      }
+    } else if (contains(range, fromB)) {
+      const removed = toA - fromA;
+      const inserted = toB - fromA;
+      const to = range.to + inserted - removed;
+      if (to <= range.from || hasInvalidChars(text.toString())) {
+        tracker = null;
+      } else {
+        const abbrRange = tracker.inactive ? range : { from: range.from, to };
+        const nextTracker = createTracker(state, abbrRange, {
+          config: tracker.config,
+          forced: tracker.forced,
+        });
+
+        if (!nextTracker) {
+          // Next tracker is empty mostly due to invalid abbreviation.
+          // To allow users to fix error, keep previous tracker
+          // instance as inactive
+          tracker = { ...tracker, inactive: true };
+        } else {
+          tracker = nextTracker;
+        }
+      }
+    }
+  });
+
+  return tracker;
 }
 
 function getSyntaxFromPos(state: EditorState, pos: number): string {
-    if (cssLanguage.isActiveAt(state, pos)) {
-        return 'css';
-    }
+  if (cssLanguage.isActiveAt(state, pos)) {
+    return "css";
+  }
 
-    if (htmlLanguage.isActiveAt(state, pos)) {
-        return 'html';
-    }
+  if (htmlLanguage.isActiveAt(state, pos)) {
+    return "html";
+  }
 
-    return '';
+  return "";
 }
 
 function canStartTyping(prefix: string, input: string, syntax: string) {
-    return isValidPrefix(prefix, syntax) && isValidAbbreviationStart(input, syntax);
+  return (
+    isValidPrefix(prefix, syntax) && isValidAbbreviationStart(input, syntax)
+  );
 }
 
 /**
@@ -674,59 +779,82 @@ function canStartTyping(prefix: string, input: string, syntax: string) {
  * Should ask package authors how to properly detect it
  */
 function hasSnippet(state: any): boolean {
-    if (Array.isArray(state.values)) {
-        return state.values.some((item: any) => item && item.constructor?.name === 'ActiveSnippet');
-    }
+  if (Array.isArray(state.values)) {
+    return state.values.some(
+      (item: any) => item && item.constructor?.name === "ActiveSnippet"
+    );
+  }
 
+  return false;
+}
+
+export function canDisplayPreview(
+  state: EditorState,
+  tracker: AbbreviationTracker
+): boolean {
+  if (completionStatus(state) === "active") {
     return false;
+  }
+
+  const config = getEmmetConfig(state);
+  if (!config.previewEnabled) {
+    return false;
+  }
+
+  if (Array.isArray(config.previewEnabled)) {
+    const { type, syntax } = tracker.config;
+    if (
+      !config.previewEnabled.includes(type!) &&
+      !config.previewEnabled.includes(syntax!)
+    ) {
+      return false;
+    }
+  }
+
+  return (
+    tracker.type === "error" ||
+    ((!tracker.simple || tracker.forced) &&
+      !!tracker.abbreviation &&
+      contains(tracker.range, getCaret(state)))
+  );
 }
 
-export function canDisplayPreview(state: EditorState, tracker: AbbreviationTracker): boolean {
-    if (completionStatus(state) === 'active') {
-        return false;
-    }
-
-    const config = getEmmetConfig(state);
-    if (!config.previewEnabled) {
-        return false;
-    }
-
-    if (Array.isArray(config.previewEnabled)) {
-        const { type, syntax } = tracker.config;
-        if (!config.previewEnabled.includes(type!) && !config.previewEnabled.includes(syntax!)) {
-            return false;
-        }
-    }
-
-    return tracker.type === 'error' || (!tracker.simple || tracker.forced) && !!tracker.abbreviation && contains(tracker.range, getCaret(state));
-}
-
-function completionOptionsFromTracker(state: EditorState, tracker: AbbreviationTrackerValid, prev?: EmmetCompletion): EmmetCompletion[] {
-    const opt = state.facet(config);
-    return [{
-        label: 'Emmet abbreviation',
-        type: 'emmet',
-        boost: opt.completionBoost,
-        tracker,
-        previewConfig: opt.preview,
-        preview: prev?.preview,
-        info: completionInfo,
-        apply: (view, completion) => {
-            view.dispatch({
-                annotations: pickedCompletion.of(completion)
-            });
-            expandTracker(view, tracker);
-        }
-    }];
+function completionOptionsFromTracker(
+  state: EditorState,
+  tracker: AbbreviationTrackerValid,
+  prev?: EmmetCompletion
+): EmmetCompletion[] {
+  const opt = state.facet(config);
+  return [
+    {
+      label: "Emmet abbreviation",
+      type: "emmet",
+      boost: opt.completionBoost,
+      tracker,
+      previewConfig: opt.preview,
+      preview: prev?.preview,
+      info: completionInfo,
+      apply: (view, completion) => {
+        view.dispatch({
+          annotations: pickedCompletion.of(completion),
+        });
+        expandTracker(view, tracker);
+      },
+    },
+  ];
 }
 
 function completionInfo(completion: Completion): Node {
-    let { tracker, previewConfig, preview } = completion as EmmetCompletion;
-    if (preview?.update) {
-        preview.update(tracker.preview);
-    } else {
-        (completion as EmmetCompletion).preview = preview = createPreview(tracker.preview, tracker.config.syntax || 'html', previewConfig);
-    }
+  let { tracker, previewConfig, preview } = completion as EmmetCompletion;
+  if (preview?.update) {
+    preview.update(tracker.preview);
+  } else {
+    (completion as EmmetCompletion).preview = preview = createPreview(
+      tracker.preview,
+      tracker.config.syntax || "html",
+      previewConfig
+    );
+  }
 
-    return preview;
+  return preview;
 }


### PR DESCRIPTION
Use TypeScript enum for `EmmetKnownSytnax` and reference values throughout instead of strings

https://github.com/emmetio/codemirror6-plugin/issues/23

Note that I'm not sure the best approach to testing and I don't know if I found all of the strings that should be referencing the enum instead. Hopefully this is a helpful start, but make sure it's up to your standard :-)