### PR TITLE
Switch EmmetKnownSyntax to enum

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import type { GlobalConfig } from 'emmet';
 import { EditorState, type Extension, Facet } from '@codemirror/state';
 import { resetCache } from './emmet';
-import type { EmmetKnownSyntax } from './types';
+import { EmmetKnownSyntax } from './types';
 
 export interface EmmetEditorOptions {
     emmet: EmmetConfig;
@@ -104,7 +104,7 @@ export interface EmmetConfig {
 }
 
 export const defaultConfig: EmmetConfig = {
-    syntax: 'html',
+    syntax: EmmetKnownSyntax.html,
     mark: true,
     preview: { },
     previewEnabled: true,

--- a/src/lib/emmet.ts
+++ b/src/lib/emmet.ts
@@ -7,7 +7,7 @@ import { syntaxInfo, getMarkupAbbreviationContext, getStylesheetAbbreviationCont
 import { getTagAttributes, substr } from './utils';
 import getEmmetConfig from './config';
 import getOutputOptions, { field } from './output';
-import type { ContextTag } from './types';
+import { EmmetKnownSyntax, type ContextTag } from './types';
 
 export interface ExtractedAbbreviationWithContext extends ExtractedAbbreviation {
     context?: AbbreviationContext;
@@ -120,7 +120,7 @@ export function getOptions(state: EditorState, pos: number): UserConfig {
 
     const config: UserConfig = {
         type: info.type,
-        syntax: info.syntax || 'html',
+        syntax: info.syntax || EmmetKnownSyntax.html,
         options: getOutputOptions(state, info.inline)
     };
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -2,9 +2,10 @@ import type { Options } from 'emmet';
 import type { EditorState, Line } from '@codemirror/state';
 import getEmmetConfig from './config';
 import { isHTML, docSyntax } from './syntax';
+import { EmmetKnownSyntax } from './types';
 
 export default function getOutputOptions(state: EditorState, inline?: boolean): Partial<Options> {
-    const syntax = docSyntax(state) || 'html';
+    const syntax = docSyntax(state) || EmmetKnownSyntax.html;
     const config = getEmmetConfig(state);
 
     const opt: Partial<Options> = {
@@ -17,7 +18,7 @@ export default function getOutputOptions(state: EditorState, inline?: boolean): 
         'stylesheet.shortHex': config.shortHex
     };
 
-    if (syntax === 'html') {
+    if (syntax === EmmetKnownSyntax.html) {
         opt['output.selfClosingStyle'] = config.markupStyle;
         opt['output.compactBoolean'] = config.markupStyle === 'html';
     }

--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -3,16 +3,16 @@ import type { EditorState } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import type { SyntaxNode } from '@lezer/common';
 import { getContext } from './context';
-import type { HTMLContext, CSSContext, EmmetKnownSyntax } from './types';
+import { HTMLContext, CSSContext, EmmetKnownSyntax } from './types';
 import { last, getTagAttributes } from './utils';
 import getEmmetConfig from './config';
 
-const htmlSyntaxes: EmmetKnownSyntax[] = ['html', 'vue'];
-const jsxSyntaxes: EmmetKnownSyntax[] = ['jsx', 'tsx'];
-const xmlSyntaxes: EmmetKnownSyntax[] = ['xml', 'xsl', ...jsxSyntaxes];
-const cssSyntaxes: EmmetKnownSyntax[] = ['css', 'scss', 'less'];
-const markupSyntaxes: EmmetKnownSyntax[] = ['haml', 'jade', 'pug', 'slim', ...htmlSyntaxes, ...xmlSyntaxes, ...jsxSyntaxes];
-const stylesheetSyntaxes: EmmetKnownSyntax[] = ['sass', 'sss', 'stylus', 'postcss', ...cssSyntaxes];
+const htmlSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.html, EmmetKnownSyntax.vue];
+const jsxSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.jsx, EmmetKnownSyntax.tsx];
+const xmlSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.xml, EmmetKnownSyntax.xsl, ...jsxSyntaxes];
+const cssSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.css, EmmetKnownSyntax.scss, EmmetKnownSyntax.less];
+const markupSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.haml, EmmetKnownSyntax.jade, EmmetKnownSyntax.pug, EmmetKnownSyntax.slim, ...htmlSyntaxes, ...xmlSyntaxes, ...jsxSyntaxes];
+const stylesheetSyntaxes: EmmetKnownSyntax[] = [EmmetKnownSyntax.sass, EmmetKnownSyntax.sss, EmmetKnownSyntax.stylus, EmmetKnownSyntax.postcss, ...cssSyntaxes];
 
 export interface SyntaxInfo {
     type: SyntaxType;
@@ -65,10 +65,10 @@ export function syntaxInfo(state: EditorState, ctx?: number | HTMLContext | CSSC
 
     if (context?.type === 'html' && context.css) {
         inline = true;
-        syntax = 'css';
+        syntax = EmmetKnownSyntax.css;
         context = context.css;
     } else if (context?.type === 'css') {
-        syntax = 'css';
+        syntax = EmmetKnownSyntax.css;
     }
 
     return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,25 @@
 import type { AbbreviationContext, UserConfig } from 'emmet';
 import type { EditorState, Transaction } from '@codemirror/state';
 
-export type EmmetKnownSyntax = 'html' | 'xml' | 'xsl' | 'jsx' | 'tsx' | 'vue'
-    | 'haml' | 'jade' | 'pug' | 'slim'
-    | 'css' | 'scss' | 'less' | 'sass' | 'sss' | 'stylus' | 'postcss';
+export enum EmmetKnownSyntax {
+  html = 'html',
+  xml = 'xml',
+  xsl = 'xsl',
+  jsx = 'jsx',
+  tsx = 'tsx',
+  vue = 'vue',
+  haml = 'haml',
+  jade = 'jade',
+  pug = 'pug',
+  slim = 'slim',
+  css = 'css',
+  scss = 'scss',
+  less = 'less',
+  sass = 'sass',
+  sss = 'sss',
+  stylus = 'stylus',
+  postcss = 'postcss'
+}
 
 export type CSSTokenType = 'selector' | 'propertyName' | 'propertyValue';
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,7 +27,7 @@ new EditorView({
 */
 export { enterAbbreviationMode, emmetCompletionSource } from './tracker';
 export { config as emmetConfig, type EmmetConfig } from './lib/config';
-export type { EmmetKnownSyntax } from './lib/types';
+export { EmmetKnownSyntax } from './lib/types';
 export { expandAbbreviation } from './commands/expand';
 export { balanceOutward, balanceInward } from './commands/balance';
 export { toggleComment } from './commands/comment';

--- a/src/tracker/AbbreviationPreviewWidget.ts
+++ b/src/tracker/AbbreviationPreviewWidget.ts
@@ -4,6 +4,7 @@ import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language'
 import { html } from '@codemirror/lang-html';
 import { css } from '@codemirror/lang-css';
 import type { EmmetPreviewConfig, PreviewExtensions } from '../lib/config';
+import { EmmetKnownSyntax } from '../plugin';
 
 export interface HTMLElementPreview extends HTMLElement {
     update?: (value: string) => void;
@@ -16,7 +17,7 @@ export function createPreview(value: string, syntax: string, options?: EmmetPrev
         elem.classList.add('emmet-preview_error');
     }
 
-    let ext: PreviewExtensions = syntax === 'css' ? css : html;
+    let ext: PreviewExtensions = syntax === EmmetKnownSyntax.css ? css : html;
     if (options && syntax in options) {
         ext = options[syntax as keyof EmmetPreviewConfig]!;
     }
@@ -26,7 +27,7 @@ export function createPreview(value: string, syntax: string, options?: EmmetPrev
         extensions: [
             EditorState.readOnly.of(true),
             syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-            syntax === 'css' ? css() : html(),
+            syntax === EmmetKnownSyntax.css ? css() : html(),
             ext()
         ],
         parent: elem


### PR DESCRIPTION
Use TypeScript enum for EmmetKNownSytnax and reference values throughout instead of strings. 
(clean with no interference from Prettier)

https://github.com/emmetio/codemirror6-plugin/issues/23

Note that I'm not sure the best approach to testing and I don't know if I found all of the strings that should be referencing the enum instead. Hopefully this is a helpful start, but make sure it's up to your standard :-)
